### PR TITLE
refactor: remplazar uso auditoria-estado por programa-estado

### DIFF
--- a/src/auditoria/auditoria.service.ts
+++ b/src/auditoria/auditoria.service.ts
@@ -33,7 +33,7 @@ export class AuditoriaService {
     await Promise.all(
       data.Data.map(async (auditoria: any) => {
         const [estado, auditores] = await Promise.all([
-          this.getEstadoAuditoria(auditoria._id),
+          this.getEstadoProgramaAuditoria(auditoria._id),
           this.asociarAuditores(auditoria._id),
         ]);
 
@@ -218,8 +218,8 @@ export class AuditoriaService {
     }
   }
 
-  private async getEstadoAuditoria(auditoriaId: string) {
-    const url = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria-estado?query=auditoria_id:${auditoriaId},actual:true`;
+  private async getEstadoProgramaAuditoria(auditoriaId: string) {
+    const url = `${PLAN_AUDITORIA_CRUD_SERVICE}programa-estado?query=auditoria_id:${auditoriaId},actual:true`;
     try {
       const { data } = await lastValueFrom(this.httpService.get(url));
       if (data?.Data?.length > 0) {
@@ -228,7 +228,7 @@ export class AuditoriaService {
       return null;
     } catch (error) {
       throw new HttpException(
-        'Error al obtener los datos del estado',
+        'Error al obtener los datos del estado del programa de auditoría',
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }


### PR DESCRIPTION
Answers to [Implementación programa de trabajo estado #459](https://github.com/udistrital/sisifo_documentacion/issues/459)

This pull request updates how the audit status is retrieved in the `AuditoriaService`, switching from fetching the audit status to fetching the audit program status. The changes also update error messaging to more accurately reflect the new logic in migration to for the database change.

**Audit status retrieval updates:**

* Replaced the call to `getEstadoAuditoria` with `getEstadoProgramaAuditoria` when mapping audit data, ensuring the service now fetches the audit program status instead of the deprecated audit status.
* Renamed and updated the private method from `getEstadoAuditoria` to `getEstadoProgramaAuditoria`, and changed the endpoint from `auditoria-estado` to `programa-estado` to match the new logic.

**Error messaging improvements:**

* Updated the error message thrown when failing to retrieve the audit program status, making it clear that the error is related to the audit program status data.