### PR TITLE
feat: Integración registro de información de informe 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,19 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@nestjs/axios": "^3.1.1",
+        "@nestjs/axios": "^3.1.3",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
-        "@nestjs/swagger": "^8.0.7",
+        "@nestjs/swagger": "^8.1.1",
         "@types/js-yaml": "^4.0.9",
         "axios": "^1.7.7",
         "js-yaml": "^4.1.0",
         "moment": "^2.30.1",
         "reflect-metadata": "^0.2.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -86,6 +87,16 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular-devkit/schematics": {
@@ -198,6 +209,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1509,9 +1530,10 @@
       "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA=="
     },
     "node_modules/@nestjs/axios": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.1.1.tgz",
-      "integrity": "sha512-ySoxrzqX80P1q6LKLKGcgyBd2utg4gbC+4FsJNpXYvILorMlxss/ECNogD9EXLCE4JS5exVFD5ez0nK5hXcNTQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.1.3.tgz",
+      "integrity": "sha512-RZ/63c1tMxGLqyG3iOCVt7A72oy4x1eM6QEhd4KzCYpaVWW0igq0WSREeRoEZhIxRcZfDfIIkvsOMiM7yfVGZQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
         "axios": "^1.3.1",
@@ -7602,9 +7624,10 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8189,6 +8212,21 @@
       "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -20,18 +20,19 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs/axios": "^3.1.1",
+    "@nestjs/axios": "^3.1.3",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/swagger": "^8.0.7",
+    "@nestjs/swagger": "^8.1.1",
     "@types/js-yaml": "^4.0.9",
     "axios": "^1.7.7",
     "js-yaml": "^4.1.0",
     "moment": "^2.30.1",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.2",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
@@ -72,6 +73,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { PlantillaModule } from './plantilla/plantilla.module';
 import { CargueMasivoModule } from './cargue-masivo/cargue-masivo.module';
 import { PlanEstadoModule } from './plan-estado/plan-estado.module';
 import { AuditorModule } from './auditor/auditor.module';
+import { InformeModule } from './informe/informe.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { AuditorModule } from './auditor/auditor.module';
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    InformeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/informe/informe.controller.spec.ts
+++ b/src/informe/informe.controller.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { InformeController } from './informe.controller';
+import { InformeService } from './informe.service';
+
+describe('InformeController', () => {
+  let controller: InformeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InformeController],
+      providers: [
+        InformeService,
+        {
+          provide: HttpService,
+          useValue: {
+            get: jest.fn(),
+            post: jest.fn(),
+            put: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InformeController>(InformeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/informe/informe.controller.ts
+++ b/src/informe/informe.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+  HttpStatus,
+  Res,
+  Query,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { InformeService } from './informe.service';
+
+@ApiTags('Informe')
+@Controller('informe')
+export class InformeController {
+  constructor(private readonly informeService: InformeService) {}
+
+  @Get(':id')
+  @ApiOperation({ 
+    summary: 'Obtener informe consolidado para edición',
+    description: 'Retorna el informe con auditoría, estado actual, historial de estados, hallazgos y temas'
+  })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del informe (MongoDB ObjectId)' })
+  @ApiResponse({ status: 200, description: 'Informe obtenido exitosamente con datos complementarios' })
+  @ApiResponse({ status: 404, description: 'Informe no encontrado' })
+  async getById(@Res() res: any, @Param('id') id: string) {
+    try {
+      const data = await this.informeService.getInformeCompleto(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: data
+      });
+    } catch (error) {
+      res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
+        Success: false,
+        Status: error.status || HttpStatus.INTERNAL_SERVER_ERROR,
+        Message: error.message || 'Error al obtener el informe',
+        Data: null
+      });
+    }
+  }
+
+  @Get()
+  @ApiOperation({ 
+    summary: 'Obtener todos los informes',
+    description: 'Lista informes con filtros opcionales y datos complementarios básicos'
+  })
+  @ApiResponse({ status: 200, description: 'Informes obtenidos exitosamente' })
+  async getAll(@Res() res: any, @Query() queryParams: any) {
+    try {
+      const data = await this.informeService.getAll(queryParams);
+      res.status(HttpStatus.OK).json(data);
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error en servicio GetAll: sin datos o parámetro inválido',
+        Data: error.message
+      });
+    }
+  }
+
+  @Get('auditoria/:auditoriaId')
+  @ApiOperation({ 
+    summary: 'Obtener informes por auditoría',
+    description: 'Lista todos los informes activos de una auditoría específica'
+  })
+  @ApiParam({ name: 'auditoriaId', type: 'string', description: 'ID de la auditoría' })
+  @ApiResponse({ status: 200, description: 'Informes de la auditoría obtenidos' })
+  async getByAuditoria(@Res() res: any, @Param('auditoriaId') auditoriaId: string) {
+    try {
+      const data = await this.informeService.getByAuditoria(auditoriaId);
+      res.status(HttpStatus.OK).json(data);
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error al obtener informes de la auditoría',
+        Data: error.message
+      });
+    }
+  }
+
+  @Put(':id')
+  @ApiOperation({ 
+    summary: 'Actualizar un informe',
+    description: 'Actualiza los datos de un informe existente'
+  })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del informe' })
+  @ApiResponse({ status: 200, description: 'Informe actualizado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos de entrada inválidos' })
+  @ApiResponse({ status: 404, description: 'Informe no encontrado' })
+  async update(@Res() res: any, @Param('id') id: string, @Body() body: any) {
+    try {
+      const data = await this.informeService.update(id, body);
+      res.status(HttpStatus.OK).json(data);
+    } catch (error) {
+      res.status(error.status || HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: error.status || HttpStatus.BAD_REQUEST,
+        Message: error.message || 'Error en servicio Put: datos incorrectos o inválidos',
+        Data: null
+      });
+    }
+  }
+
+}

--- a/src/informe/informe.module.ts
+++ b/src/informe/informe.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { InformeController } from './informe.controller';
+import { InformeService } from './informe.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [InformeController],
+  providers: [InformeService],
+  exports: [InformeService],
+})
+export class InformeModule {}

--- a/src/informe/informe.service.spec.ts
+++ b/src/informe/informe.service.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { InformeService } from './informe.service';
+
+describe('InformeService', () => {
+  let service: InformeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InformeService,
+        {
+          provide: HttpService,
+          useValue: {
+            get: jest.fn(),
+            post: jest.fn(),
+            put: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<InformeService>(InformeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/informe/informe.service.ts
+++ b/src/informe/informe.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { lastValueFrom, forkJoin, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from 'src/config/configuration';
+
+const { PLAN_AUDITORIA_CRUD_SERVICE } = environment;
+
+@Injectable()
+export class InformeService {
+  private readonly logger = new Logger(InformeService.name);
+
+  constructor(private readonly httpService: HttpService) {}
+
+  async getInformeCompleto(id: string) {
+    try {
+      this.logger.log(`Consultando informe completo con ID: ${id}`);
+
+      // Obtener informe base del CRUD
+      const informeBase = await lastValueFrom(
+        this.httpService.get(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${id}`).pipe(
+          map(res => res.data.Data),
+          catchError(() => {
+            throw new HttpException(
+              `Informe con ID ${id} no encontrado`,
+              HttpStatus.NOT_FOUND
+            );
+          })
+        )
+      );
+
+      // Orquestar llamadas paralelas para complementar datos
+      const complementos$ = forkJoin({
+        auditoria: this.httpService
+          .get(`${PLAN_AUDITORIA_CRUD_SERVICE}auditoria/${informeBase.auditoria_id}`)
+          .pipe(
+            map(res => res.data.Data),
+            catchError((error) => {
+              this.logger.warn(`No se pudo obtener auditoría: ${error.message}`);
+              return of(null);
+            })
+          ),
+
+        hallazgos: this.httpService
+          .get(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${id}/hallazgos`)
+          .pipe(
+            map(res => res.data.Data),
+            catchError((error) => {
+              this.logger.warn(`No se pudieron obtener hallazgos: ${error.message}`);
+              return of([]);
+            })
+          ),
+
+        temas: this.httpService
+          .get(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${id}/tema`)
+          .pipe(
+            map(res => res.data.Data),
+            catchError((error) => {
+              this.logger.warn(`No se pudieron obtener temas: ${error.message}`);
+              return of([]);
+            })
+          ),
+
+        estado_actual: this.httpService
+          .get(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${id}/estado-actual`)
+          .pipe(
+            map(res => res.data.Data),
+            catchError((error) => {
+              this.logger.warn(`No se pudo obtener estado actual: ${error.message}`);
+              return of(null);
+            })
+          ),
+
+        historial_estados: this.httpService
+          .get(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${id}/estados`)
+          .pipe(
+            map(res => res.data.Data),
+            catchError((error) => {
+              this.logger.warn(`No se pudo obtener historial de estados: ${error.message}`);
+              return of([]);
+            })
+          )
+      });
+
+      const infoExtra = await lastValueFrom(complementos$);
+
+      // Consolidar toda la información
+      const informeCompleto = {
+        ...informeBase,
+        ...infoExtra
+      };
+
+      this.logger.log(`Informe ${id} consultado exitosamente con datos complementarios`);
+      return informeCompleto;
+
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      this.logger.error(`Error al obtener informe completo: ${error.message}`, error.stack);
+      throw new HttpException(
+        'Error al obtener el informe completo',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+  async getAll(queryParams: any) {
+    try {
+      const queryString = new URLSearchParams(queryParams).toString();
+      const url = `${PLAN_AUDITORIA_CRUD_SERVICE}informe?${queryString}`;
+
+      const response = await lastValueFrom(
+        this.httpService.get(url).pipe(
+          map(res => res.data),
+          catchError(() => {
+            throw new HttpException(
+              'Error al obtener informes',
+              HttpStatus.INTERNAL_SERVER_ERROR
+            );
+          })
+        )
+      );
+
+      // Complementar cada informe con datos básicos de auditoría y estado
+      if (response.Data && Array.isArray(response.Data)) {
+        const informesConComplementos = await Promise.all(
+          response.Data.map(async (informe: any) => {
+            const complementos$ = forkJoin({
+              auditoria: this.httpService
+                .get(`${PLAN_AUDITORIA_CRUD_SERVICE}auditoria/${informe.auditoria_id}`)
+                .pipe(
+                  map(res => res.data.Data),
+                  catchError(() => of(null))
+                ),
+
+              estado_actual: this.httpService
+                .get(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${informe._id}/estado-actual`)
+                .pipe(
+                  map(res => res.data.Data),
+                  catchError(() => of(null))
+                )
+            });
+
+            const extras = await lastValueFrom(complementos$);
+            return { ...informe, ...extras };
+          })
+        );
+
+        response.Data = informesConComplementos;
+      }
+
+      return response;
+
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      this.logger.error(`Error al obtener todos los informes: ${error.message}`, error.stack);
+      throw new HttpException(
+        'Error al obtener informes',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+  async getByAuditoria(auditoriaId: string) {
+    try {
+      this.logger.log(`Consultando informes de auditoría ${auditoriaId}`);
+
+      const queryParams = {
+        query: `auditoria_id:${auditoriaId},activo:true`,
+        sortby: 'fecha_creacion',
+        order: 'desc',
+        limit: '100'
+      };
+
+      return await this.getAll(queryParams);
+
+    } catch (error) {
+      this.logger.error(
+        `Error al consultar informes por auditoría: ${error.message}`,
+        error.stack
+      );
+      throw new HttpException(
+        'Error al consultar informes por auditoría',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+  async update(id: string, body: any) {
+    try {
+      this.logger.log(`Actualizando informe con ID: ${id}`);
+
+      const response = await lastValueFrom(
+        this.httpService.put(`${PLAN_AUDITORIA_CRUD_SERVICE}informe/${id}`, body).pipe(
+          map(res => res.data),
+          catchError((error) => {
+            throw new HttpException(
+              error.response?.data?.Message || 'Error al actualizar informe',
+              error.response?.status || HttpStatus.BAD_REQUEST
+            );
+          })
+        )
+      );
+
+      this.logger.log(`Informe ${id} actualizado exitosamente`);
+      return response;
+
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      this.logger.error(`Error al actualizar informe: ${error.message}`, error.stack);
+      throw new HttpException(
+        'Error al actualizar informe',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,6 @@ async function bootstrap() {
 
   //Enable CORS
   app.enableCors();
-  await app.listen(parseInt(port, 10) || 8080);
+  await app.listen(parseInt(port, 10) || 8081);
 }
 bootstrap();

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -474,6 +474,107 @@
           "Plantilla"
         ]
       }
+    },
+    "/informe/{id}": {
+      "get": {
+        "description": "Retorna el informe con auditoría, estado actual, historial de estados, hallazgos y temas",
+        "operationId": "InformeController_getById",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "ID del informe (MongoDB ObjectId)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Informe obtenido exitosamente con datos complementarios"
+          },
+          "404": {
+            "description": "Informe no encontrado"
+          }
+        },
+        "summary": "Obtener informe consolidado para edición",
+        "tags": [
+          "Informe"
+        ]
+      },
+      "put": {
+        "description": "Actualiza los datos de un informe existente",
+        "operationId": "InformeController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "ID del informe",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Informe actualizado exitosamente"
+          },
+          "400": {
+            "description": "Datos de entrada inválidos"
+          },
+          "404": {
+            "description": "Informe no encontrado"
+          }
+        },
+        "summary": "Actualizar un informe",
+        "tags": [
+          "Informe"
+        ]
+      }
+    },
+    "/informe": {
+      "get": {
+        "description": "Lista informes con filtros opcionales y datos complementarios básicos",
+        "operationId": "InformeController_getAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Informes obtenidos exitosamente"
+          }
+        },
+        "summary": "Obtener todos los informes",
+        "tags": [
+          "Informe"
+        ]
+      }
+    },
+    "/informe/auditoria/{auditoriaId}": {
+      "get": {
+        "description": "Lista todos los informes activos de una auditoría específica",
+        "operationId": "InformeController_getByAuditoria",
+        "parameters": [
+          {
+            "name": "auditoriaId",
+            "required": true,
+            "in": "path",
+            "description": "ID de la auditoría",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Informes de la auditoría obtenidos"
+          }
+        },
+        "summary": "Obtener informes por auditoría",
+        "tags": [
+          "Informe"
+        ]
+      }
     }
   },
   "info": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -304,6 +304,72 @@ paths:
           description: Tipo de plantilla no encontrado.
       summary: Obtener plantilla dinámica según el tipo de auditoría
       tags: *ref_6
+  /informe/{id}:
+    get:
+      description: >-
+        Retorna el informe con auditoría, estado actual, historial de estados,
+        hallazgos y temas
+      operationId: InformeController_getById
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: ID del informe (MongoDB ObjectId)
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Informe obtenido exitosamente con datos complementarios
+        '404':
+          description: Informe no encontrado
+      summary: Obtener informe consolidado para edición
+      tags: &ref_7
+        - Informe
+    put:
+      description: Actualiza los datos de un informe existente
+      operationId: InformeController_update
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: ID del informe
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Informe actualizado exitosamente
+        '400':
+          description: Datos de entrada inválidos
+        '404':
+          description: Informe no encontrado
+      summary: Actualizar un informe
+      tags: *ref_7
+  /informe:
+    get:
+      description: Lista informes con filtros opcionales y datos complementarios básicos
+      operationId: InformeController_getAll
+      parameters: []
+      responses:
+        '200':
+          description: Informes obtenidos exitosamente
+      summary: Obtener todos los informes
+      tags: *ref_7
+  /informe/auditoria/{auditoriaId}:
+    get:
+      description: Lista todos los informes activos de una auditoría específica
+      operationId: InformeController_getByAuditoria
+      parameters:
+        - name: auditoriaId
+          required: true
+          in: path
+          description: ID de la auditoría
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Informes de la auditoría obtenidos
+      summary: Obtener informes por auditoría
+      tags: *ref_7
 info:
   title: Plan Anual Auditoria MID
   description: API MID para la gestion de planes de auditorias, auditorias y actividades


### PR DESCRIPTION
Finalización de la integración del formulario de registro de informe preliminar. Se implementó la lógica en el MID para centralizar consultas del CRUD y permitir la actualización de datos existentes.

## Tareas realizadas 
- **Desarrollo**: Endpoints REST de consulta y actualización en el MID.
- **Integración**: Consumo optimizado de 7 endpoints del CRUD con RxJS (forkJoin).
- **Pruebas**: Implementación de pruebas unitarias y validación funcional.
- **Documentación**: Registro de nuevos endpoints en Swagger.