### PR TITLE
feat: Inclusión opcional de auditorías especiales en formato de PAA

### DIFF
--- a/src/plantilla/dto/plantilla.dto.ts
+++ b/src/plantilla/dto/plantilla.dto.ts
@@ -24,5 +24,6 @@ export class jsonPlantillaDto {
     criterios: string;
     recursos: string;
     items: PlantillaDto[];
+    especiales?: PlantillaDto[];
   };
 }

--- a/src/plantilla/plantilla.controller.ts
+++ b/src/plantilla/plantilla.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { PlantillaService } from './services/plantilla.service';
 import { PlantillaPlanTrabajoService } from './services/plantilla-plan-trabajo.service';
 import { PlantillaSolicitudInformacionService } from './services/plantilla-solicitud-informacion.service';
@@ -24,9 +24,19 @@ export class PlantillaController {
   @Get(':id')
   @ApiOperation({ summary: 'Obtener plantilla por ID' })
   @ApiParam({ name: 'id', description: 'ID de la plantilla' })
+  @ApiQuery({
+    name: 'conEspeciales',
+    required: false,
+    default: true,
+    type: Boolean,
+    description: 'Incluir caracteres especiales en la plantilla',
+  })
   @ApiResponse({ status: 200, description: 'Plantilla encontrada.' })
-  async getById(@Param('id') id: string) {
-    return this.plantillaService.getOne(id);
+  async getById(@Param('id') id: string, @Query('conEspeciales') conEspeciales?: boolean) {
+    if (conEspeciales == null)
+      conEspeciales = true;
+
+    return this.plantillaService.getOne(id, conEspeciales);
   }
 
   @Get('/:tipo/:idAuditoria')

--- a/src/plantilla/plantilla.controller.ts
+++ b/src/plantilla/plantilla.controller.ts
@@ -27,14 +27,14 @@ export class PlantillaController {
   @ApiQuery({
     name: 'conEspeciales',
     required: false,
-    default: true,
+    default: false,
     type: Boolean,
     description: 'Incluir caracteres especiales en la plantilla',
   })
   @ApiResponse({ status: 200, description: 'Plantilla encontrada.' })
   async getById(@Param('id') id: string, @Query('conEspeciales') conEspeciales?: boolean) {
     if (conEspeciales == null)
-      conEspeciales = true;
+      conEspeciales = false;
 
     return this.plantillaService.getOne(id, conEspeciales);
   }

--- a/src/plantilla/services/plantilla.service.ts
+++ b/src/plantilla/services/plantilla.service.ts
@@ -14,8 +14,11 @@ const {
 @Injectable()
 export class PlantillaService {
   constructor(private readonly httpService: HttpService) {}
-  async getOne(id: string) {
-    const data = await this.traerDataCrud(id);
+  async getOne(id: string, conEspeciales: boolean) {
+    let data = await this.traerDataCrud(id);
+    if (conEspeciales)
+      data = await this.anadirDataEspeciales(data);
+
     const baseJson = await this.organizarData(data);
     const baseRenderizado = await this.renderizar(baseJson);
     return baseRenderizado;
@@ -43,12 +46,35 @@ export class PlantillaService {
     }
   }
 
+  /**
+   * Recover special audit program (same vigencia bur no PAA) data and add it to the main data object.
+   * @param data The main data object containing the audit plan and audits.
+   * @returns The updated data object with the special audit data included.
+   */
+  private async anadirDataEspeciales(data: any) {
+    const vigenciaId = data.dataPlanAuditoria.Data?.vigencia_id;
+    const urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria?query=vigencia_id:${vigenciaId},plan_anual_auditoria_id__is_null:true,activo:true&fields=titulo,cronograma_id&limit=0`;
+
+    try {
+      const responseAuditoriaEspecial = await lastValueFrom(
+        this.httpService.get(urlAuditioria),
+      );
+      let dataAuditoriaEspecial = responseAuditoriaEspecial.data;
+
+      return { ...data, dataAuditoriaEspecial };
+    } catch (error) {
+      throw new HttpException(
+        'Error al obtener los datos de auditoría especial del servicio externo ',
+        error,
+      );
+    }
+  }
+
   private async organizarData(data: any) {
     const json = new jsonPlantillaDto();
 
     const auditorias = data.dataAuditoria?.Data || [];
     const auditoriasOrden = data.dataPlanAuditoria?.Data?.auditorias || [];
-
     const auditoriasOrdenadas = this.ordenarAuditorias(
       auditorias,
       auditoriasOrden,
@@ -56,6 +82,19 @@ export class PlantillaService {
 
     const items: PlantillaDto[] = Array.isArray(auditorias)
       ? auditoriasOrdenadas.map((auditoria: any) =>
+          this.organizarItems(auditoria),
+        )
+      : [];
+
+    const auditoriasEspeciales = data.dataAuditoriaEspecial?.Data || [];
+    const auditoriasEspecialesOrden = data.dataPlanAuditoria?.Data?.auditorias_especiales || [];
+    const auditoriasEspecialesOrdenadas = this.ordenarAuditorias(
+      auditoriasEspeciales,
+      auditoriasEspecialesOrden,
+    );
+
+    const especiales: PlantillaDto[] = Array.isArray(auditoriasEspeciales)
+      ? auditoriasEspecialesOrdenadas.map((auditoria: any) =>
           this.organizarItems(auditoria),
         )
       : [];
@@ -69,6 +108,7 @@ export class PlantillaService {
       criterios: data.dataPlanAuditoria.Data?.criterio || '',
       recursos: data.dataPlanAuditoria.Data?.recurso || '',
       items: items,
+      especiales: especiales,
     };
 
     return json;

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -460,7 +460,7 @@
             "in": "query",
             "description": "Incluir caracteres especiales en la plantilla",
             "schema": {
-              "default": true,
+              "default": false,
               "type": "boolean"
             }
           }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -453,6 +453,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "conEspeciales",
+            "required": false,
+            "in": "query",
+            "description": "Incluir caracteres especiales en la plantilla",
+            "schema": {
+              "default": true,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -290,6 +290,13 @@ paths:
           description: ID de la plantilla
           schema:
             type: string
+        - name: conEspeciales
+          required: false
+          in: query
+          description: Incluir caracteres especiales en la plantilla
+          schema:
+            default: true
+            type: boolean
       responses:
         '200':
           description: Plantilla encontrada.

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -295,7 +295,7 @@ paths:
           in: query
           description: Incluir caracteres especiales en la plantilla
           schema:
-            default: true
+            default: false
             type: boolean
       responses:
         '200':


### PR DESCRIPTION
This pull request introduces support for including "especiales" (special audit items) in the plantilla (template) returned by the API. It adds an optional query parameter to the plantilla endpoint, updates the service to fetch and organize the special audits, and documents the new parameter in the API specs. The main changes are grouped below.

- Answers to udistrital/sisifo_documentacion#493

**API Enhancements:**

* Added an optional `conEspeciales` boolean query parameter to the `GET /plantilla/:id` endpoint in `PlantillaController`. When set to true, this includes special audit items in the response. The parameter is also documented with Swagger decorators. [[1]](diffhunk://#diff-834f3eb934f3dc52b25e5dc9f71ff7494207dfb025db26da8d7947194b326bfeL1-R2) [[2]](diffhunk://#diff-834f3eb934f3dc52b25e5dc9f71ff7494207dfb025db26da8d7947194b326bfeR27-R39)
* Updated the OpenAPI/Swagger documentation (`swagger.json` and `swagger.yaml`) to include the new `conEspeciales` query parameter for the endpoint. [[1]](diffhunk://#diff-b26e2bac465eb45f43f4907194fbbf4d689c8223613b2be6f9cec26f882da350R456-R465) [[2]](diffhunk://#diff-67da153f3e0510d70a5c5e94380688cc14fd76b0193caaabe2c51bf33460992cR293-R299)

**Service and Data Structure Updates:**

* Modified `PlantillaService.getOne` to accept the `conEspeciales` parameter, fetch special audit data when requested, and integrate it into the plantilla's data. [[1]](diffhunk://#diff-e90b02659d299fefac2df4815f412c3347297e283c2f5f8b4962587568588184L17-R21) [[2]](diffhunk://#diff-e90b02659d299fefac2df4815f412c3347297e283c2f5f8b4962587568588184R49-L51)
* Enhanced the data organization logic to process and include `especiales` (special audits) in the plantilla's output. [[1]](diffhunk://#diff-e90b02659d299fefac2df4815f412c3347297e283c2f5f8b4962587568588184R89-R101) [[2]](diffhunk://#diff-e90b02659d299fefac2df4815f412c3347297e283c2f5f8b4962587568588184R111)
* Updated the `jsonPlantillaDto` data transfer object to add an optional `especiales` property for holding special audit items.