### PR TITLE
feat: Implementar exportado de tabla de auditorías de un PAA

### DIFF
--- a/src/application/cargue-masivo/cargue-masivo.controller.ts
+++ b/src/application/cargue-masivo/cargue-masivo.controller.ts
@@ -5,13 +5,15 @@ import {
   HttpException,
   HttpStatus,
   Get,
-  Res,
+  Param,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiQuery, ApiParam } from '@nestjs/swagger';
 import { CargueMasivoService } from './cargue-masivo.service';
 import axios from 'axios';
 import { environment } from 'src/config/configuration';
 import { NuxeoService } from 'src/shared/utils/nuxeo/nuxeo.service';
+// TODO: In the future, the auditoriaService dependency should be removed by modularizing the ordenadas method to avoid coupling between modules
+import { AuditoriaService } from 'src/auditoria/auditoria.service';
 import { firstValueFrom } from 'rxjs';
 
 @ApiTags('Cargue Masivo')
@@ -20,6 +22,7 @@ export class CargueMasivoController {
   constructor(
     private readonly cargueMasivoService: CargueMasivoService,
     private readonly nuxeoService: NuxeoService,
+    private readonly auditoriaService: AuditoriaService,
   ) {}
 
   private cargueMasivoUrl = `${environment.CARGUE_MASIVO_SERVERLESS_MID}registro-datos-archivo`;
@@ -58,6 +61,58 @@ export class CargueMasivoController {
       console.error('Error al descargar la plantilla:', error);
       throw new HttpException(
         'Error al descargar la plantilla',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Get('auditorias/:planId')
+  @ApiOperation({ summary: 'Descargar auditorías en formato Excel' })
+  @ApiResponse({ status: 500, description: 'Error interno.' })
+  @ApiParam({ name: 'planId', required: true, description: 'ID del plan de auditoría.' })
+  @ApiResponse({
+    status: 200,
+    description: 'Archivo de auditorías descargado exitosamente.',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            base64: {
+              type: 'string',
+              description: 'Archivo de auditorías en formato Base64.',
+            },
+          },
+        },
+      },
+    },
+  })
+  async descargarAuditoriasExcel(
+    @Param('planId') planId: string
+  ): Promise<{ base64: string }> {
+    try {
+      // TODO: In the future, the ordenadas method will be modularized to avoid dependency on the auditoriaService
+      const ordenadas = await this.auditoriaService.getAuditoriasOrdenadas({ query: `plan_auditoria_id:${planId}` });
+      const plantillaResponse = await firstValueFrom(
+        this.nuxeoService.obtenerPorUUID(
+          environment.PLANTILLA_CARGUE_MASIVO_AUDITORIAS
+        )
+      );
+      if (!ordenadas || !ordenadas.Data)
+        throw new HttpException(
+          'No se encontraron auditorías para el plan especificado',
+          HttpStatus.NOT_FOUND,
+        );
+
+      const tablaExportada = await this.cargueMasivoService.exportarAuditoriasExcel(
+          ordenadas.Data,
+          plantillaResponse
+        );
+      return { base64: tablaExportada };
+    } catch (error) {
+      console.error('Error al descargar las auditorías en Excel:', error);
+      throw new HttpException(
+        'Error al descargar las auditorías en Excel',
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }

--- a/src/application/cargue-masivo/cargue-masivo.module.ts
+++ b/src/application/cargue-masivo/cargue-masivo.module.ts
@@ -4,9 +4,11 @@ import { CargueMasivoService } from './cargue-masivo.service';
 import { HttpModule } from '@nestjs/axios';
 import { NuxeoModule } from 'src/shared/utils/nuxeo/nuxeo.module';
 import { DominiosModule } from 'src/shared/utils/dominios/dominios.module';
+import { AuditoriaModule } from 'src/auditoria/auditoria.module';
 
 @Module({
-  imports: [HttpModule, NuxeoModule, DominiosModule],
+  // TODO: In the future, the AuditoriaModule dependency should be removed by modularizing the ordenadas method to avoid coupling between modules.
+  imports: [HttpModule, NuxeoModule, DominiosModule, AuditoriaModule],
   controllers: [CargueMasivoController],
   providers: [CargueMasivoService]
 })

--- a/src/application/cargue-masivo/cargue-masivo.service.ts
+++ b/src/application/cargue-masivo/cargue-masivo.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { environment } from 'src/config/configuration';
-import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { DominiosService } from 'src/shared/utils/dominios/dominios.service';
-import { setupValidationDomains } from 'src/shared/utils/auditoriasExcel.utils';
+import { setupValidationDomains, descargarAuditorias, AuditoriaExcel } from 'src/shared/utils/auditoriasExcel.utils';
 import {
   base64ToArrayBuffer,
   arrayBufferToBase64,
@@ -51,7 +50,6 @@ interface Parametro {
 @Injectable()
 export class CargueMasivoService {
   constructor(
-    private readonly httpService: HttpService,
     private readonly dominiosService: DominiosService,
   ) {}
 
@@ -59,6 +57,8 @@ export class CargueMasivoService {
    * Add validation domains and formulaes to the template before downloading it,
    * including 'Tipo de Evaluación', 'Macroproceso', 'Proceso' and 'Dependencia'.
    * @param plantillaBase64 The original template in Base64 format.
+   * @return A promise that resolves with the modified template in Base64 format, including the added validation domains and formulas.
+   * @throws An error if the process of adding validations fails, with a message indicating the failure and the original error stack trace.
    */
   async agregarValidaciones(plantillaBase64: string): Promise<string> {
     try {
@@ -74,6 +74,36 @@ export class CargueMasivoService {
     }
     catch (error) {
       const newError = new Error('Failed to add validations to the template');
+      newError.stack += "\nCaused by: " + error.stack;
+      throw newError;
+    }
+  }
+
+  /**
+   * Exports the given data source to an Excel file using the provided template, and adds validation domains to the resulting file.
+   * @param dataSource An array of AuditoriaExcel objects representing the data to be exported.
+   * @param plantillaBase64 The template to be used for exporting, in Base64 format.
+   * @returns A promise that resolves with the exported Excel file in Base64 format.
+   * @throws An error if the export process fails, with a message indicating the failure and the original error stack trace.
+   */
+  async exportarAuditoriasExcel(
+    dataSource: Array<AuditoriaExcel>,
+    plantillaBase64: string
+  ): Promise<string> {
+    try {
+      const tablaExportadaBuffer = await descargarAuditorias(
+          dataSource,
+          base64ToArrayBuffer(plantillaBase64)
+        );
+      const tablaConValidacionBuffer = await setupValidationDomains(
+        await this.prepararHeadersValidacion(),
+        [ { sheetIndex: 0 , length: dataSource.length + 1 } ],
+        tablaExportadaBuffer,
+      );
+      return arrayBufferToBase64(tablaConValidacionBuffer);
+    }
+    catch (error) {
+      const newError = new Error('Failed to export auditorias to Excel');
       newError.stack += "\nCaused by: " + error.stack;
       throw newError;
     }

--- a/src/auditoria/auditoria.module.ts
+++ b/src/auditoria/auditoria.module.ts
@@ -8,5 +8,7 @@ import { AuditorModule } from '../auditor/auditor.module';
   imports: [HttpModule, AuditorModule],
   controllers: [AuditoriaController],
   providers: [AuditoriaService],
+  // TODO: In the future, the ordenadas method should be modularized to avoid coupling between modules, allowing the removal of the AuditoriaService dependency from the CargueMasivoModule.
+  exports: [AuditoriaService],
 })
 export class AuditoriaModule {}

--- a/src/shared/utils/auditoriasExcel.utils.ts
+++ b/src/shared/utils/auditoriasExcel.utils.ts
@@ -26,6 +26,127 @@ const HEADERS = [
   ...MESES_ARCHIVO
 ];
 
+/** Class representing the structure of an audit to be exported to Excel.  */
+export class AuditoriaExcel {
+  titulo: string;
+  tipo_evaluacion_nombre: string;
+  macroproceso_nombre?: string;
+  proceso_nombre?: string;
+  dependencia_nombre?: string;
+  cronograma_nombre: Array<string>;
+}
+
+/**
+ * Transforms the dataSource into a format suitable for Excel export
+ * @returns An array of objects representing the data in the desired Excel format
+ */
+function dataSourceToExcelData(dataSource: Array<AuditoriaExcel>): Array<object> {
+  // 1. Load basic data from dataSource in the desired format
+  let data: {[key: string]: Array<string>} = {
+    // ID
+    [HEADERS[0]]: Array.from(Array(dataSource.length).keys())
+                    .map(i => (i + 1).toString()),
+    // Auditoria
+    [HEADERS[1]]: dataSource.map(a => a.titulo),
+    // Tipo de Evaluación
+    [HEADERS[2]]: dataSource.map(a => a.tipo_evaluacion_nombre),
+    // Macroproceso
+    [HEADERS[3]]: dataSource.map(a => a.macroproceso_nombre || ''),
+    // Proceso
+    [HEADERS[4]]: dataSource.map(a => a.proceso_nombre || ''),
+    // Dependencia
+    [HEADERS[5]]: dataSource.map(a => a.dependencia_nombre || ''),
+  };
+
+  // 2. Transform cronograma into month columns
+  const cronogramaMatriz = dataSource.map(cronograma =>
+    MESES_ARCHIVO.map(prefijoMes => {
+      const mesIndex = cronograma.cronograma_nombre.findIndex(m =>
+        m.includes(prefijoMes)
+      );
+      return mesIndex !== -1 ? 'x' : '';
+    })
+  );
+  let mesesData: {[key: string]: string[]} = {};
+  MESES_ARCHIVO.forEach((mes, index) => {
+    mesesData[mes] = cronogramaMatriz.map(cronograma => cronograma[index]);
+  });
+
+  data = { ...data, ...mesesData };
+
+  // Create final array of objects maintaining HEADERS order
+  const numRows = dataSource.length;
+  let finalData: Array<object> = [];
+  for (let i = 0; i < numRows; i++) {
+    let row: {[key: string]: string} = {};
+    HEADERS.forEach(header => {
+      row[header] = data[header][i];
+    });
+    finalData.push(row);
+  }
+
+  return finalData;
+}
+
+/**
+ * Creates the Excel file for the given audit data.
+ * @param dataSource The array of audit data to be exported. See {@link AuditoriaExcel} for structure.
+ * @param inputBuffer An ArrayBuffer containing the Excel template file data.
+ * @returns A Promise that resolves to an ArrayBuffer containing the Excel file data.
+ * @throws If any issue occurs during the Excel generation process.
+ */
+export async function descargarAuditorias(
+    dataSource: Array<AuditoriaExcel>,
+    inputBuffer: ArrayBuffer,
+): Promise<ArrayBuffer> {
+  try{
+    // Load the template workbook from the Base64 string and select the first worksheet
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(inputBuffer);
+    const worksheet = workbook.worksheets[0];
+
+    // Prepare to write data starting from row 2, skipping header row
+    const rows = dataSourceToExcelData(dataSource);
+    const maxRowIndex = Math.max(dataSheetOriginalMaxRows, dataSheetStartRowIndex + rows.length - 1);
+
+    // Write data into worksheet by modifying existing rows (keep styles)
+    rows.forEach((rowObj, rowIdx) => {
+      const excelRow = worksheet.getRow(dataSheetStartRowIndex + rowIdx);
+      HEADERS.forEach((hdr, colIdx) => {
+        const cell = excelRow.getCell(colIdx + 1);
+        const value = (rowObj as any)[hdr] ?? '';
+        cell.value = value;
+      });
+      excelRow.commit();
+    });
+
+    // Give new rows the same style and border as the original template rows
+    const sourceRow = worksheet.getRow(dataSheetOriginalMaxRows);
+    for (let r = dataSheetOriginalMaxRows + 1; r <= maxRowIndex; r++) {
+      const targetRow = worksheet.getRow(r);
+      HEADERS.forEach((_, colIdx) => {
+        const sourceCell = sourceRow.getCell(colIdx + 1);
+        const targetCell = targetRow.getCell(colIdx + 1);
+        targetCell.style = sourceCell.style;
+        targetCell.border = sourceCell.border;
+      });
+      targetRow.commit();
+    }
+
+    // Remove example worksheet
+    const exampleSheet = workbook.getWorksheet('ejemplo');
+    if (exampleSheet)
+      workbook.removeWorksheet(exampleSheet.id);
+
+    return await workbook.xlsx.writeBuffer();
+  }
+  catch (error) {
+    const newError = new Error('Error al incrustar los datos en la plantilla de Excel.');
+    newError.stack += "\nCaused by: " + (error instanceof Error ? error.stack : String(error));
+    throw newError;
+  }
+}
+
 /**
  * Configures the validation domains in the Excel template based on the provided valid options for each header. 
  * @param headersValidacion An object mapping header names to arrays of valid values for data validation.

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -309,6 +309,47 @@
         ]
       }
     },
+    "/cargue-masivo/auditorias/{planId}": {
+      "get": {
+        "operationId": "CargueMasivoController_descargarAuditoriasExcel",
+        "parameters": [
+          {
+            "name": "planId",
+            "required": true,
+            "in": "path",
+            "description": "ID del plan de auditoría.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Archivo de auditorías descargado exitosamente.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "base64": {
+                      "type": "string",
+                      "description": "Archivo de auditorías en formato Base64."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error interno."
+          }
+        },
+        "summary": "Descargar auditorías en formato Excel",
+        "tags": [
+          "Cargue Masivo"
+        ]
+      }
+    },
     "/cargue-masivo/auditorias": {
       "post": {
         "operationId": "CargueMasivoController_cargueMasivo",

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -194,6 +194,31 @@ paths:
       summary: Descargar plantilla de auditorías
       tags: &ref_3
         - Cargue Masivo
+  /cargue-masivo/auditorias/{planId}:
+    get:
+      operationId: CargueMasivoController_descargarAuditoriasExcel
+      parameters:
+        - name: planId
+          required: true
+          in: path
+          description: ID del plan de auditoría.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Archivo de auditorías descargado exitosamente.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  base64:
+                    type: string
+                    description: Archivo de auditorías en formato Base64.
+        '500':
+          description: Error interno.
+      summary: Descargar auditorías en formato Excel
+      tags: *ref_3
   /cargue-masivo/auditorias:
     post:
       operationId: CargueMasivoController_cargueMasivo


### PR DESCRIPTION
This pull request introduces a new feature for exporting audit data to Excel in the Cargue Masivo module, along with supporting changes to enable this functionality. The most important changes are the addition of a new endpoint for downloading audit data as an Excel file, integration with the Auditoria module, and the implementation of the Excel export logic. The changes are grouped below by theme.

- Answers to udistrital/sisifo_documentacion#523

### New Feature: Export Audit Data to Excel

* Added the `descargarAuditoriasExcel` endpoint to `CargueMasivoController`, allowing users to download audit data for a specified plan in Excel format (Base64) via a GET request to `/cargue-masivo/auditorias/:planId`. This includes Swagger documentation and error handling. [[1]](diffhunk://#diff-d025787dc66c264ffb0a7ed6850091d1f96eaea8e9e96feb486239347113d25bR69-R120) [[2]](diffhunk://#diff-b26e2bac465eb45f43f4907194fbbf4d689c8223613b2be6f9cec26f882da350R312-R352) [[3]](diffhunk://#diff-67da153f3e0510d70a5c5e94380688cc14fd76b0193caaabe2c51bf33460992cR197-R221)
* Implemented the `exportarAuditoriasExcel` method in `CargueMasivoService`, which transforms audit data and exports it to Excel using a template, adding validation domains. This method handles errors and returns the result as a Base64 string.

### Integration and Dependency Updates

* Integrated `AuditoriaService` as a dependency in `CargueMasivoController` and updated `CargueMasivoModule` to import `AuditoriaModule` for access to audit data. Added comments indicating future plans to modularize the dependency. [[1]](diffhunk://#diff-d025787dc66c264ffb0a7ed6850091d1f96eaea8e9e96feb486239347113d25bL8-R16) [[2]](diffhunk://#diff-d025787dc66c264ffb0a7ed6850091d1f96eaea8e9e96feb486239347113d25bR25) [[3]](diffhunk://#diff-e4f00f837459b99bc37e2f7d508ea7b911eccc153804e0299a8f4c08852efa5bR7-R11) [[4]](diffhunk://#diff-ee29b27c8bedf4291fbd7cbd5f946ac36ce1d2ea532e33450c2c22588337928bR11-R12)

### Excel Export Logic

* Added the `AuditoriaExcel` class and the `descargarAuditorias` function to `auditoriasExcel.utils.ts`, which transform audit data into the required Excel format and generate the Excel file using the template. This includes handling month columns and styling.

### Documentation Improvements

* Enhanced JSDoc comments for new and existing methods to clarify their purpose, parameters, and error handling. [[1]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L54-R61) [[2]](diffhunk://#diff-1b4f7c465b3a140da93ca1157dcbbd76d0ddd4f4d66c2b52b5ac328067ee718aR29-R149)

---

These changes collectively enable the new audit export functionality and ensure proper integration and documentation for maintainability and future improvements.