### PR TITLE
refactor: Se ha cambiado el endpoint para exportar tabla de auditorías en PAA

### DIFF
--- a/src/application/cargue-masivo/cargue-masivo.controller.ts
+++ b/src/application/cargue-masivo/cargue-masivo.controller.ts
@@ -66,7 +66,7 @@ export class CargueMasivoController {
     }
   }
 
-  @Get('auditorias/:planId')
+  @Get('auditorias/plan/:planId')
   @ApiOperation({ summary: 'Descargar auditorías en formato Excel' })
   @ApiResponse({ status: 500, description: 'Error interno.' })
   @ApiParam({ name: 'planId', required: true, description: 'ID del plan de auditoría.' })

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -309,7 +309,7 @@
         ]
       }
     },
-    "/cargue-masivo/auditorias/{planId}": {
+    "/cargue-masivo/auditorias/plan/{planId}": {
       "get": {
         "operationId": "CargueMasivoController_descargarAuditoriasExcel",
         "parameters": [

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -194,7 +194,7 @@ paths:
       summary: Descargar plantilla de auditorías
       tags: &ref_3
         - Cargue Masivo
-  /cargue-masivo/auditorias/{planId}:
+  /cargue-masivo/auditorias/plan/{planId}:
     get:
       operationId: CargueMasivoController_descargarAuditoriasExcel
       parameters:


### PR DESCRIPTION
This pull request updates the route for downloading audit reports in Excel format to make the endpoint path more descriptive and consistent. The change affects the controller as well as the API documentation files.

- Answers to  udistrital/sisifo_documentacion#523

**API Endpoint Update:**

* Changed the route in `CargueMasivoController` from `/cargue-masivo/auditorias/{planId}` to `/cargue-masivo/auditorias/plan/{planId}` to clarify that the `planId` refers to an audit plan.

**API Documentation Updates:**

* Updated the path in `swagger/swagger.json` to reflect the new endpoint: `/cargue-masivo/auditorias/plan/{planId}`.
* Updated the path in `swagger/swagger.yaml` to match the new endpoint: `/cargue-masivo/auditorias/plan/{planId}`.