### PR TITLE
feat: agregar macroproceso, proceso y dependencia a payload a lambda de cargue masivo de PAA 

### DIFF
--- a/src/application/cargue-masivo/cargue-masivo.service.ts
+++ b/src/application/cargue-masivo/cargue-masivo.service.ts
@@ -11,6 +11,7 @@ import {
 const {
   PLAN_AUDITORIA_CRUD_SERVICE,
   TIPO_EVALUACION,
+  TIPO_PARAMETRO,
   MESES,
 } = environment;
 
@@ -27,12 +28,6 @@ const MESES_MAPPING = {
   Oct: MESES.OCTUBRE,
   Nov: MESES.NOVIEMBRE,
   Dic: MESES.DICIEMBRE,
-};
-
-const TIPO_EVALUACION_MAPPING = {
-  'Auditoria Interna': TIPO_EVALUACION.AUDITORIA_INTERNA,
-  Seguimiento: TIPO_EVALUACION.SEGUIMIENTO,
-  Informe: TIPO_EVALUACION.INFORME,
 };
 
 const MEDIO_MAPPING = {
@@ -132,7 +127,7 @@ export class CargueMasivoService {
     return opciones;
   }
 
-  crearEstructura(base64data: string, complemento: Object): any {
+  async crearEstructura(base64data: string, complemento: Object): Promise<any> {
     return {
       base64data,
       service: PLAN_AUDITORIA_CRUD_SERVICE,
@@ -143,7 +138,22 @@ export class CargueMasivoService {
         tipo_evaluacion_id: {
           file_name_column: 'Tipo de Evaluación',
           required: true,
-          mapping: TIPO_EVALUACION_MAPPING,
+          mapping: await this.getParametrosMapping(TIPO_PARAMETRO.TIPO_EVALUACION),
+        },
+        macroproceso_id: {
+          file_name_column: 'Macroproceso',
+          required: false,
+          mapping: await this.getParametrosMapping(TIPO_PARAMETRO.MACROPROCESO),
+        },
+        proceso_id: {
+          file_name_column: 'Proceso',
+          required: false,
+          mapping: await this.getParametrosMapping(TIPO_PARAMETRO.PROCESO),
+        },
+        dependencia_id: {
+          file_name_column: 'Dependencia',
+          required: false,
+          mapping: await this.getDependenciasMapping(),
         },
         cronograma_id: {
           column_group: Object.keys(MESES_MAPPING),
@@ -151,6 +161,53 @@ export class CargueMasivoService {
         },
       },
     };
+  }
+
+  /**
+   * Obtains a mapping of parameter names to their corresponding IDs for a given parameter type by fetching data from the PARAMETROS_SERVICE.
+   * @param tipoParametroId The ID of the parameter type to fetch.
+   * @returns A promise that resolves to a mapping of parameter names to IDs.
+   * @throws An error if the fetch operation fails or if the response is not in the expected format.
+   */
+  private async getParametrosMapping(tipoParametroId: number): Promise<Record<string, number>> {
+    try {
+      const dominio = await firstValueFrom(this.dominiosService.getParametros(tipoParametroId));
+      const mapping: Record<string, number> = {};
+      dominio.parametros.forEach((parametro: Parametro) => {
+        mapping[parametro.Nombre] = parametro.Id;
+      });
+
+      console.log('Mapping for tipoParametroId:', tipoParametroId, 'is:', mapping);
+      return mapping;
+    }
+    catch (error) {
+      const newError = new Error('Failed to get parametros');
+      newError.stack += "\nCaused by: " + error.stack;
+      throw newError;
+    }
+  }
+
+  /**
+   * Obtains a mapping of dependency names to their corresponding IDs by fetching data from the OIKOS_SERVICE.
+   * @returns A promise that resolves to a mapping of dependency names to IDs.
+   * @throws An error if the fetch operation fails or if the response is not in the expected format.
+   */
+  private async getDependenciasMapping(): Promise<Record<string, number>> {
+    try {
+      const dominio = await firstValueFrom(this.dominiosService.getDependencias());
+      const mapping: Record<string, number> = {};
+      dominio.parametros.forEach((parametro: Parametro) => {
+        mapping[parametro.Nombre] = parametro.Id;
+      });
+
+      console.log('Dependencias mapping is:', mapping);
+      return mapping;
+    }
+    catch (error) {
+      const newError = new Error('Failed to get dependencias');
+      newError.stack += "\nCaused by: " + error.stack;
+      throw newError;
+    }
   }
 
   crearEstructuraActividad(base64data: string, complemento: Object): any {


### PR DESCRIPTION
This pull request updates the `CargueMasivoService` to improve how parameter mappings are handled, making the code more dynamic and maintainable. Instead of using hardcoded mappings for various parameter types, the service now fetches these mappings at runtime from external services. Additionally, new fields are supported in the data structure for macroprocess, process, and dependency, each with their own dynamic mappings.

- Answers to udistrital/sisifo_documentacion#542

**Dynamic parameter mapping and field support:**

* Removed the hardcoded `TIPO_EVALUACION_MAPPING` and replaced it with a dynamic mapping fetched from the parameter service using the new `getParametrosMapping` method. (`src/application/cargue-masivo/cargue-masivo.service.ts`) [[1]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L32-L37) [[2]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L146-R156)
* Added support for new fields: `macroproceso_id`, `proceso_id`, and `dependencia_id`, each with their own dynamic mappings fetched from external services. (`src/application/cargue-masivo/cargue-masivo.service.ts`)

**Refactoring and method improvements:**

* Changed `crearEstructura` to be an `async` method to support awaiting the new mapping functions. (`src/application/cargue-masivo/cargue-masivo.service.ts`)
* Added the private methods `getParametrosMapping` and `getDependenciasMapping` to fetch mappings from external services, including error handling and logging for easier debugging. (`src/application/cargue-masivo/cargue-masivo.service.ts`)

**Configuration update:**

* Imported `TIPO_PARAMETRO` from the environment configuration to support the new dynamic mapping logic. (`src/application/cargue-masivo/cargue-masivo.service.ts`)