### PR TITLE
fix: Conversión a booleano de parámetro conEspeciales en controlador …

### DIFF
--- a/src/application/plantilla/plantilla.controller.ts
+++ b/src/application/plantilla/plantilla.controller.ts
@@ -32,11 +32,11 @@ export class PlantillaController {
     description: 'Incluir caracteres especiales en la plantilla',
   })
   @ApiResponse({ status: 200, description: 'Plantilla encontrada.' })
-  async getById(@Param('id') id: string, @Query('conEspeciales') conEspeciales?: boolean) {
+  async getById(@Param('id') id: string, @Query('conEspeciales') conEspeciales?: string) {
     if (conEspeciales == null)
-      conEspeciales = false;
+      conEspeciales = 'false';
 
-    return this.plantillaService.getOne(id, conEspeciales);
+    return this.plantillaService.getOne(id, conEspeciales === 'true');
   }
 
   @Get('/:tipo/:idAuditoria')


### PR DESCRIPTION
This pull request updates the handling of the `conEspeciales` query parameter in the `PlantillaController` to ensure correct boolean parsing from string values. The main change is to treat the query parameter as a string and explicitly convert it to a boolean before passing it to the service.

- Answers to udistrital/sisifo_documentacion#548

**Query Parameter Handling Improvements:**

* Changed the type of the `conEspeciales` query parameter from `boolean` to `string` in the `getById` method of `PlantillaController`, and updated the logic to convert the string value to a boolean (`conEspeciales === 'true'`) before calling the service. This ensures reliable parsing of query parameters, which are always received as strings in HTTP requests.