### PR TITLE
feat: consumo de auditoria-padre al renderizar Formato PAA

### DIFF
--- a/src/application/plantilla/plantilla.controller.ts
+++ b/src/application/plantilla/plantilla.controller.ts
@@ -31,12 +31,22 @@ export class PlantillaController {
     type: Boolean,
     description: 'Incluir caracteres especiales en la plantilla',
   })
+  @ApiQuery({
+    name: 'auditoria-padre',
+    required: false,
+    default: false,
+    type: Boolean,
+    description: 'Usar la auditoría padre en la plantilla en lugar de la colección de auditorías original',
+  })
   @ApiResponse({ status: 200, description: 'Plantilla encontrada.' })
-  async getById(@Param('id') id: string, @Query('conEspeciales') conEspeciales?: string) {
+  async getById(@Param('id') id: string, @Query('conEspeciales') conEspeciales?: string, @Query('auditoria-padre') auditoriaPadre?: string) {
     if (conEspeciales == null)
       conEspeciales = 'false';
 
-    return this.plantillaService.getOne(id, conEspeciales === 'true');
+    if (auditoriaPadre == null)
+      auditoriaPadre = 'false';
+
+    return this.plantillaService.getOne(id, conEspeciales === 'true', auditoriaPadre === 'true');
   }
 
   @Get('/:tipo/:idAuditoria')

--- a/src/application/plantilla/services/plantilla.service.ts
+++ b/src/application/plantilla/services/plantilla.service.ts
@@ -11,8 +11,6 @@ const {
   PLANTILLAS,
   MESES,
   PLANTILLAS_MID_SERVICE,
-  PARAMETROS_SERVICE,
-  OIKOS_SERVICE,
 } = environment;
 
 /** Interface representing a parameter with an ID and a name. */

--- a/src/application/plantilla/services/plantilla.service.ts
+++ b/src/application/plantilla/services/plantilla.service.ts
@@ -25,19 +25,20 @@ export class PlantillaService {
     private readonly httpService: HttpService,
     private readonly dominiosService: DominiosService,
   ) {}
-  async getOne(id: string, conEspeciales: boolean) {
-    let data = await this.traerDataCrud(id);
+  async getOne(id: string, conEspeciales: boolean, auditoriaPadre: boolean) {
+    let data = await this.traerDataCrud(id, auditoriaPadre);
     if (conEspeciales)
-      data = await this.anadirDataEspeciales(data);
+      data = await this.anadirDataEspeciales(data, auditoriaPadre);
 
     const baseJson = await this.organizarData(data);
     const baseRenderizado = await this.renderizar(baseJson);
     return baseRenderizado;
   }
 
-  private async traerDataCrud(id: string) {
+  private async traerDataCrud(id: string, auditoriaPadre: boolean) {
     let urlPlanAuditoria = `${PLAN_AUDITORIA_CRUD_SERVICE}plan-auditoria/${id}`;
-    let urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria-padre?query=plan_auditoria_id:${id},activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
+    let endpointAuditoria = auditoriaPadre ? 'auditoria-padre' : 'auditoria';
+    let urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}${endpointAuditoria}?query=plan_auditoria_id:${id},activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
     try {
       const responsePlanAuditoria = await lastValueFrom(
         this.httpService.get(urlPlanAuditoria),
@@ -60,11 +61,13 @@ export class PlantillaService {
   /**
    * Recover special audit program (same vigencia bur no PAA) data and add it to the main data object.
    * @param data The main data object containing the audit plan and audits.
+   * @param auditoriaPadre A boolean indicating whether to use the parent audit or the original collection of audits.
    * @returns The updated data object with the special audit data included.
    */
-  private async anadirDataEspeciales(data: any) {
+  private async anadirDataEspeciales(data: any, auditoriaPadre: boolean) {
     const vigenciaId = data.dataPlanAuditoria.Data?.vigencia_id;
-    const urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria-padre?query=vigencia_id:${vigenciaId},plan_auditoria_id__isnull:true,activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
+    let endpointAuditoria = auditoriaPadre ? 'auditoria-padre' : 'auditoria';
+    const urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}${endpointAuditoria}?query=vigencia_id:${vigenciaId},plan_auditoria_id__isnull:true,activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
 
     try {
       const responseAuditoriaEspecial = await lastValueFrom(

--- a/src/application/plantilla/services/plantilla.service.ts
+++ b/src/application/plantilla/services/plantilla.service.ts
@@ -39,7 +39,7 @@ export class PlantillaService {
 
   private async traerDataCrud(id: string) {
     let urlPlanAuditoria = `${PLAN_AUDITORIA_CRUD_SERVICE}plan-auditoria/${id}`;
-    let urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria?query=plan_auditoria_id:${id},activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
+    let urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria-padre?query=plan_auditoria_id:${id},activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
     try {
       const responsePlanAuditoria = await lastValueFrom(
         this.httpService.get(urlPlanAuditoria),
@@ -66,7 +66,7 @@ export class PlantillaService {
    */
   private async anadirDataEspeciales(data: any) {
     const vigenciaId = data.dataPlanAuditoria.Data?.vigencia_id;
-    const urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria?query=vigencia_id:${vigenciaId},plan_auditoria_id__isnull:true,activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
+    const urlAuditioria = `${PLAN_AUDITORIA_CRUD_SERVICE}auditoria-padre?query=vigencia_id:${vigenciaId},plan_auditoria_id__isnull:true,activo:true&fields=titulo,macroproceso_id,proceso_id,dependencia_id,cronograma_id&limit=0`;
 
     try {
       const responseAuditoriaEspecial = await lastValueFrom(

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -673,6 +673,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "name": "auditoria-padre",
+            "required": false,
+            "in": "query",
+            "description": "Usar la auditoría padre en la plantilla en lugar de la colección de auditorías original",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -428,6 +428,15 @@ paths:
           schema:
             default: false
             type: boolean
+        - name: auditoria-padre
+          required: false
+          in: query
+          description: >-
+            Usar la auditoría padre en la plantilla en lugar de la colección de
+            auditorías original
+          schema:
+            default: false
+            type: boolean
       responses:
         '200':
           description: Plantilla encontrada.


### PR DESCRIPTION
This pull request updates the `PlantillaService` to use the `auditoria-padre` endpoint instead of the previous `auditoria` endpoint for fetching audit-related data. This change is applied in both the `traerDataCrud` and `anadirDataEspeciales` methods to ensure consistency in how audit information is retrieved.

- Answers to udistrital/sisifo_documentacion#571

**API endpoint updates:**

* Changed the URL in the `traerDataCrud` method to use the `auditoria-padre` endpoint instead of `auditoria` for retrieving audit data by plan ID.
* Changed the URL in the `anadirDataEspeciales` method to use the `auditoria-padre` endpoint instead of `auditoria` for retrieving audit data by `vigencia_id`.

**Environment configuration cleanup:**

* Removed unused `PARAMETROS_SERVICE` and `OIKOS_SERVICE` imports from the environment configuration.