### PR TITLE
fix: Limpiar temas/estilos antes de generar binario excel 

### DIFF
--- a/src/shared/utils/auditoriasExcel.utils.ts
+++ b/src/shared/utils/auditoriasExcel.utils.ts
@@ -138,6 +138,7 @@ export async function descargarAuditorias(
     if (exampleSheet)
       workbook.removeWorksheet(exampleSheet.id);
 
+    workbook.clearThemes(); // Clear themes to avoid issues with styles when modifying the workbook
     return await workbook.xlsx.writeBuffer();
   }
   catch (error) {
@@ -247,6 +248,7 @@ export async function setupValidationDomains(
       });
     });
 
+    workbook.clearThemes(); // Clear themes to avoid issues with styles when modifying the workbook
     return await workbook.xlsx.writeBuffer();
   }
   catch (error) {


### PR DESCRIPTION
This pull request adds a step to clear Excel workbook themes in two utility functions to prevent style issues when modifying workbooks. The change helps ensure consistent formatting and reduces errors related to workbook styles.

- Answers to udistrital/sisifo_documentacion#578

Excel workbook theme clearing:

* Added `workbook.clearThemes()` before returning the workbook buffer in both `descargarAuditorias` and `setupValidationDomains` to avoid issues with styles when modifying the workbook. [[1]](diffhunk://#diff-1b4f7c465b3a140da93ca1157dcbbd76d0ddd4f4d66c2b52b5ac328067ee718aR141) [[2]](diffhunk://#diff-1b4f7c465b3a140da93ca1157dcbbd76d0ddd4f4d66c2b52b5ac328067ee718aR251)