### PR TITLE
feat: consulta y unión de auditorias padre e hija parte 2

### DIFF
--- a/src/application/auditoria/auditoria.controller.ts
+++ b/src/application/auditoria/auditoria.controller.ts
@@ -13,41 +13,6 @@ import { AuditoriaService } from './auditoria.service';
 export class AuditoriaController {
   constructor(private readonly auditoriaService: AuditoriaService) {}
 
-  @Get('ordenadas')
-  @ApiOperation({ summary: 'Obtener auditorías ordenadas' })
-  @ApiQuery({
-    name: 'plan_auditoria_id',
-    required: true,
-    description: 'ID del plan de auditoría (obligatorio).',
-  })
-  @ApiQuery({
-    name: 'orderBy',
-    required: false,
-    description: 'Campo de orden.',
-  })
-  @ApiQuery({
-    name: 'orderDirection',
-    required: false,
-    description: 'Dirección (ASC o DESC).',
-  })
-  @ApiResponse({ status: 200, description: 'Auditorías obtenidas.' })
-  @ApiResponse({ status: 400, description: 'Parámetros inválidos.' })
-  @ApiResponse({ status: 500, description: 'Error interno.' })
-  async getAuditoriasOrdenadas(@Res() res: any, @Query() queryParams: any) {
-    try {
-      const data =
-        await this.auditoriaService.getAuditoriasOrdenadas(queryParams);
-      res.status(HttpStatus.OK).json(data);
-    } catch (error) {
-      res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
-        Success: false,
-        Status: error.status || HttpStatus.INTERNAL_SERVER_ERROR,
-        Message: 'Error en servicio ordenadas: parámetro inválido o sin datos.',
-        Data: error.message,
-      });
-    }
-  }
-
   @Get('auditor/:personaId')
   @ApiOperation({ summary: 'Obtener auditorías por auditor' })
   @ApiParam({

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -6,8 +6,6 @@ import { AuditorService } from '../../auditor/auditor.service';
 import { DominiosService } from 'src/shared/utils/dominios/dominios.service';
 import { Dominio } from 'src/shared/utils/dominios/dominio.model';
 import { unirListaNombresConComas } from 'src/utils/texto.utils';
-import { AuditoriaOrdenadaService } from 'src/shared/services/auditoria-ordenada/auditoria-ordenada.service';
-import { aplicarOrdenamiento } from '../../shared/utils/auditoria-ordenamiento.utils';
 import { AuditoriaCrudService } from 'src/shared/services/auditoria-crud/auditoria-crud.service';
 
 const {
@@ -32,7 +30,6 @@ export class AuditoriaService {
     private readonly auditorService: AuditorService,
     private readonly auditoriaCrudService: AuditoriaCrudService,
     private readonly dominiosService: DominiosService,
-    private readonly auditoriaOrdenadaService: AuditoriaOrdenadaService,
   ) {}
 
   async getAll(queryParams: any) {
@@ -40,8 +37,11 @@ export class AuditoriaService {
     const auditorias: any[] = data1.Data;
     
     const padres_ids: string[] = auditorias.map(auditoria => auditoria?.auditoria_padre_id);
-    const queryParams2 = { query: `_id__in:${padres_ids.join("|")}`}
-    
+    const queryParams2 = {
+      ...queryParams,
+      query: `${queryParams.query},_id__in:${padres_ids.join("|")}`
+    }
+
     const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams2);
     const auditorias_padre: any[] = data2.Data;
     
@@ -175,7 +175,7 @@ export class AuditoriaService {
 
   async getOne(id: string) {
     const auditoria = await this.auditoriaCrudService.traerDataCrud('auditoria', id, null);
-    const auditoria_padre = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', auditoria.auditoria_padre_id, null);
+    const auditoria_padre = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', auditoria.Data.auditoria_padre_id, null);
     const data = { ...auditoria, Data: {...auditoria_padre.Data, ...auditoria.Data}};
     if (await this.identificarCampo(data)) {
       this.reemplazarCampos(data);
@@ -229,9 +229,9 @@ export class AuditoriaService {
 
         const [estado, auditores] = await Promise.all(promises);
 
-        if (estado[0]?.actual) {
-          auditoria.estado = estado[0];
-          auditoria.estado_id = estado[0]?.estado_id;
+        if (estado.Data[0]?.actual) {
+          auditoria.estado = estado.Data[0];
+          auditoria.estado_id = estado.Data[0]?.estado_id;
         }
         if (incluirAuditores) auditoria.auditores = auditores || [];
       })
@@ -243,79 +243,6 @@ export class AuditoriaService {
       (dep) => dep.Id === dependenciaId
     );
     return dependencia ? dependencia.CorreoElectronico : 'Correo no encontrado';
-  }
-
-  async getAuditoriasOrdenadas(queryParams: any) {
-    const planId = this.extraerPlanId(queryParams);
-
-    // Extraer filtros adicionales del query string
-    const filtros: any = {};
-    if (queryParams.query) {
-      const queryParts = queryParams.query.split(',');
-      queryParts.forEach((part: string) => {
-        if (part.startsWith('tipo_evaluacion_id:')) {
-          filtros.tipo_evaluacion_id = part.split(':')[1];
-        }
-      });
-    }
-    if (queryParams.tipo_evaluacion_id) {
-      filtros.tipo_evaluacion_id = queryParams.tipo_evaluacion_id;
-    }
-
-    // Usar servicio compartido para obtener auditorías ordenadas (sin orderBy aún)
-    const auditoriasOrdenadas = await this.auditoriaOrdenadaService.getAuditoriasOrdenadas(
-      planId,
-      undefined,
-      undefined,
-      filtros,
-    );
-
-    const data = {
-      Data: auditoriasOrdenadas,
-      Success: true,
-      Status: 200,
-    };
-
-    // Enriquecer con estados
-    await Promise.all(
-      data.Data.map(async (auditoria: any) => {
-        const queryParams = { query: `auditoria_id:${auditoria._id},actual:true`}
-        const estado = await this.auditoriaCrudService.traerDataCrud('auditoria-estado', null, queryParams);
-        if (estado[0]?.actual) {
-          auditoria.estado_id = estado[0].estado_id;
-        }
-      }),
-    );
-
-    // Identificar y reemplazar campos ANTES de ordenar
-    if (await this.identificarCampo(data)) {
-      this.reemplazarCampos(data);
-    }
-
-    // Aplicar ordenamiento DESPUÉS de reemplazar campos
-    if (queryParams.orderBy) {
-      data.Data = aplicarOrdenamiento(data.Data, queryParams.orderBy, queryParams.orderDirection);
-    }
-
-    return data;
-  }
-
-  private extraerPlanId(queryParams: any): string {
-    if (queryParams.plan_auditoria_id) {
-      return queryParams.plan_auditoria_id;
-    }
-
-    if (queryParams.query) {
-      const match = queryParams.query.match(/plan_auditoria_id:([^,]+)/);
-      if (match?.[1]) {
-        return match[1];
-      }
-    }
-
-    throw new HttpException(
-      'El parámetro "plan_auditoria_id" es obligatorio.',
-      HttpStatus.BAD_REQUEST,
-    );
   }
 
 private async identificarCampo(data: any) {

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -33,27 +33,28 @@ export class AuditoriaService {
   ) {}
 
   async getAll(queryParams: any) {
-    const data1 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, queryParams);
-    const auditorias: any[] = data1.Data;
-    
-    const padres_ids: string[] = auditorias.map(auditoria => auditoria?.auditoria_padre_id);
-    const queryParams2 = {
-      ...queryParams,
-      query: `${queryParams.query},_id__in:${padres_ids.join("|")}`
+    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams);
+    const auditoriasPadre: any[] = data.Data;
+    if (auditoriasPadre.length > 0) {
+      const padresIds: string[] = auditoriasPadre.map(auditoria => auditoria?._id);
+      const hijasFilter = { query: `auditoria_padre_id__in:${padresIds.join('|')}`}
+  
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, hijasFilter);
+      const auditorias: any[] = data2.Data;
+      
+      const padresMap = Object.fromEntries(auditoriasPadre.map(p => [p?._id, p]));
+      const auditorias_unidas: any[] = auditorias.map(a => {
+        if (a?.auditoria_padre_id in padresMap) {
+          return {
+            ...(padresMap[a?.auditoria_padre_id] || {}),
+            ...a,
+          };
+        }
+      });
+      
+      data.Data = auditorias_unidas;
     }
-
-    const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams2);
-    const auditorias_padre: any[] = data2.Data;
     
-    const padresMap = Object.fromEntries(auditorias_padre.map(p => [p?._id, p]));
-    const auditorias_unidas: any[] = auditorias.map(a => {
-      return {
-        ...(padresMap[a?.auditoria_padre_id] || {}),
-        ...a,
-      };
-    });
-    
-    const data = { ...data1, Data : auditorias_unidas }
 
     await this.enriquecerAuditorias(data.Data);
     if (await this.identificarCampo(data)) {
@@ -73,6 +74,32 @@ export class AuditoriaService {
     }
 
     const data = await this.auditoriaCrudService.traerDataCrud('auditoria/auditor', personaId, crudParams);
+    const auditorias: any[] = data.Data;
+
+    if (auditorias.length > 0) {
+      const padres_ids: string[] = auditorias.map(a => a?.auditoria_padre_id);
+      if (crudParams?.query) {
+        crudParams.query += `,_id__in:${padres_ids.join("|")}`
+      } else {
+        crudParams.query = `_id__in:${padres_ids.join("|")}`
+      }
+  
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams);
+      const auditorias_padre: any[] = data2.Data;
+      
+      const padresMap = Object.fromEntries(auditorias_padre.map(p => [p?._id, p]));
+      const auditorias_unidas: any[] = auditorias.map(a => {
+        if (a?.auditoria_padre_id in padresMap) {
+          return {
+            ...(padresMap[a?.auditoria_padre_id] || {}),
+            ...a,
+          };
+        }
+      });
+  
+      data.Data = auditorias_unidas;
+    }
+    
     await this.enriquecerAuditorias(data.Data);
 
     if (estado_id && estado_id !== '') {
@@ -113,7 +140,29 @@ export class AuditoriaService {
       ? `${baseQuery},${additionalFilters}`
       : additionalFilters;
 
-    const data = await this.auditoriaCrudService.traerDataCrud('auditoria', null, queryParams);
+    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams);
+    const auditorias: any[] = data.Data;
+
+    if (auditorias.length > 0) {
+      const ids: string[] = auditorias.map(a => a?._id);
+      const padresFilter = { query: `auditoria_padre_id__in:${ids.join('|')}`}
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, padresFilter);
+      const auditorias_hijas: any[] = data2.Data;
+  
+      const padresMap = Object.fromEntries(auditorias.map(p => [p?._id, p]));
+      const auditorias_unidas: any[] = auditorias_hijas.map(a => {
+        if (a?.auditoria_padre_id in padresMap) {
+          return {
+            ...(padresMap[a?.auditoria_padre_id] || {}),
+            ...a,
+          };
+        }
+      });
+  
+      data.Data = auditorias_unidas;
+    }
+    
+
     if (data.Data && Array.isArray(data.Data) && data.Data.length > 0) {
       const dependenciaNombres =
         await this.getDependenciaNombres(dependenciaIds);

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -33,13 +33,36 @@ export class AuditoriaService {
   ) {}
 
   async getAll(queryParams: any) {
-    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams);
+    const queryEstado = queryParams.query
+        .split(',')
+        .filter((param: string) => param.startsWith('estado_id:'))[0]
+    
+    if (queryParams.query) {
+      queryParams.query = queryParams.query
+        .split(',')
+        .filter((param: string) => !param.startsWith('estado_id:'))
+        .join(',');
+    }
+
+    const queryPadre = {
+      query: queryParams.query,
+      limit: 0,
+      fields: '_id,titulo,tipo_evaluacion_id,macroproceso_id,proceso_id,dependencia_id'
+    }
+
+    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryPadre);
     const auditoriasPadre: any[] = data.Data;
     if (auditoriasPadre.length > 0) {
       const padresIds: string[] = auditoriasPadre.map(auditoria => auditoria?._id);
-      const hijasFilter = { query: `auditoria_padre_id__in:${padresIds.join('|')}`}
-  
-      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, hijasFilter);
+      
+      const nuevaQuery = queryEstado ? 
+        `${queryEstado},activo:true,auditoria_padre_id__in:${padresIds.join('|')}` :
+        `activo:true,auditoria_padre_id__in:${padresIds.join('|')}`;
+
+      const queryHijas = { ...queryParams, query: nuevaQuery }
+      console.log(queryHijas)
+      
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, queryHijas);
       const auditorias: any[] = data2.Data;
       
       const padresMap = Object.fromEntries(auditoriasPadre.map(p => [p?._id, p]));
@@ -53,6 +76,7 @@ export class AuditoriaService {
       });
       
       data.Data = auditorias_unidas;
+      data.MetaData.Count = auditorias_unidas.length;
     }
     
 
@@ -98,6 +122,7 @@ export class AuditoriaService {
       });
   
       data.Data = auditorias_unidas;
+      data.MetaData.Count = auditorias_unidas.length;
     }
     
     await this.enriquecerAuditorias(data.Data);
@@ -160,6 +185,7 @@ export class AuditoriaService {
       });
   
       data.Data = auditorias_unidas;
+      data.MetaData.Count = auditorias_unidas.length;
     }
     
 

--- a/src/application/cargue-masivo/cargue-masivo.controller.ts
+++ b/src/application/cargue-masivo/cargue-masivo.controller.ts
@@ -12,8 +12,7 @@ import { CargueMasivoService } from './cargue-masivo.service';
 import axios from 'axios';
 import { environment } from 'src/config/configuration';
 import { NuxeoService } from 'src/shared/utils/nuxeo/nuxeo.service';
-// TODO: In the future, the auditoriaService dependency should be removed by modularizing the ordenadas method to avoid coupling between modules
-import { AuditoriaService } from '../auditoria/auditoria.service';
+import { AuditoriaPadreService } from '../auditoria-padre/auditoria-padre.service';
 import { firstValueFrom } from 'rxjs';
 
 @ApiTags('Cargue Masivo')
@@ -22,7 +21,7 @@ export class CargueMasivoController {
   constructor(
     private readonly cargueMasivoService: CargueMasivoService,
     private readonly nuxeoService: NuxeoService,
-    private readonly auditoriaService: AuditoriaService,
+    private readonly auditoriaPadreService: AuditoriaPadreService,
   ) {}
 
   private cargueMasivoUrl = `${environment.CARGUE_MASIVO_SERVERLESS_MID}registro-datos-archivo`;
@@ -92,7 +91,7 @@ export class CargueMasivoController {
   ): Promise<{ base64: string }> {
     try {
       // TODO: In the future, the ordenadas method will be modularized to avoid dependency on the auditoriaService
-      const ordenadas = await this.auditoriaService.getAuditoriasOrdenadas({ query: `plan_auditoria_id:${planId}` });
+      const ordenadas = await this.auditoriaPadreService.getAuditoriasOrdenadas({ query: `plan_auditoria_id:${planId}` });
       const plantillaResponse = await firstValueFrom(
         this.nuxeoService.obtenerPorUUID(
           environment.PLANTILLA_CARGUE_MASIVO_AUDITORIAS

--- a/src/application/cargue-masivo/cargue-masivo.module.ts
+++ b/src/application/cargue-masivo/cargue-masivo.module.ts
@@ -4,11 +4,10 @@ import { CargueMasivoService } from './cargue-masivo.service';
 import { HttpModule } from '@nestjs/axios';
 import { NuxeoModule } from 'src/shared/utils/nuxeo/nuxeo.module';
 import { DominiosModule } from 'src/shared/utils/dominios/dominios.module';
-import { AuditoriaModule } from '../auditoria/auditoria.module';
+import { AuditoriaPadreModule } from '../auditoria-padre/auditoria-padre.module';
 
 @Module({
-  // TODO: In the future, the AuditoriaModule dependency should be removed by modularizing the ordenadas method to avoid coupling between modules.
-  imports: [HttpModule, NuxeoModule, DominiosModule, AuditoriaModule],
+  imports: [HttpModule, NuxeoModule, DominiosModule, AuditoriaPadreModule],
   controllers: [CargueMasivoController],
   providers: [CargueMasivoService]
 })

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -123,49 +123,6 @@
         ]
       }
     },
-    "/auditoria/ordenadas": {
-      "get": {
-        "operationId": "AuditoriaController_getAuditoriasOrdenadas",
-        "parameters": [
-          {
-            "name": "orderDirection",
-            "required": false,
-            "in": "query",
-            "description": "Dirección (ASC o DESC).",
-            "schema": {}
-          },
-          {
-            "name": "orderBy",
-            "required": false,
-            "in": "query",
-            "description": "Campo de orden.",
-            "schema": {}
-          },
-          {
-            "name": "plan_auditoria_id",
-            "required": true,
-            "in": "query",
-            "description": "ID del plan de auditoría (obligatorio).",
-            "schema": {}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Auditorías obtenidas."
-          },
-          "400": {
-            "description": "Parámetros inválidos."
-          },
-          "500": {
-            "description": "Error interno."
-          }
-        },
-        "summary": "Obtener auditorías ordenadas",
-        "tags": [
-          "Auditoria"
-        ]
-      }
-    },
     "/auditoria/auditor/{personaId}": {
       "get": {
         "operationId": "AuditoriaController_getByAuditor",

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -77,35 +77,6 @@ paths:
           description: No se encontró el estado.
       summary: Obtiene un estado de auditoría por ID.
       tags: *ref_1
-  /auditoria/ordenadas:
-    get:
-      operationId: AuditoriaController_getAuditoriasOrdenadas
-      parameters:
-        - name: orderDirection
-          required: false
-          in: query
-          description: Dirección (ASC o DESC).
-          schema: {}
-        - name: orderBy
-          required: false
-          in: query
-          description: Campo de orden.
-          schema: {}
-        - name: plan_auditoria_id
-          required: true
-          in: query
-          description: ID del plan de auditoría (obligatorio).
-          schema: {}
-      responses:
-        '200':
-          description: Auditorías obtenidas.
-        '400':
-          description: Parámetros inválidos.
-        '500':
-          description: Error interno.
-      summary: Obtener auditorías ordenadas
-      tags: &ref_2
-        - Auditoria
   /auditoria/auditor/{personaId}:
     get:
       operationId: AuditoriaController_getByAuditor
@@ -122,7 +93,8 @@ paths:
         '404':
           description: Sin resultados.
       summary: Obtener auditorías por auditor
-      tags: *ref_2
+      tags: &ref_2
+        - Auditoria
   /auditoria/auditado/{personaId}/{cargoId}:
     get:
       operationId: AuditoriaController_getByDependencia


### PR DESCRIPTION
feat: se retira endpoint 'ordenadas' de controlador de auditorias hijas, se ajusta cargue masivo para que consuma 'ordenadas' de auditorías padre. Consulta y unión de auditorias padre e hija udistrital/sisifo_documentacion#595