### PR TITLE
feat: Añadir herencia de filtros en getByAuditor y getByDependencia en servicio

### DIFF
--- a/src/application/auditoria/auditoria.service.spec.ts
+++ b/src/application/auditoria/auditoria.service.spec.ts
@@ -55,19 +55,20 @@ describe('AuditoriaService', () => {
     it('getByAuditor debe heredar tipo_evaluacion_id y dependencia_id desde padre', async () => {
       // preparar mocks: traerDataCrud llamado para 'auditoria/auditor', 'auditoria-padre', 'auditoria-estado'
       mockCrudService.traerDataCrud.mockImplementation((resource: string, id: any, params: any) => {
-        if (resource === 'auditoria/auditor') {
+        if (resource === 'auditoria-padre') {
           return Promise.resolve({
             Data: [{
-              _id: 'h1',
-              auditoria_padre_id: 'p1',
+              _id: 'p1',
+              tipo_evaluacion_id: 7,
+              dependencia_id: 42,
               cronograma_nombre: [],
-              titulo: 'Hija'
+              titulo: 'Padre'
             }],
             MetaData: { Count: 1 },
           });
         }
-        if (resource === 'auditoria-padre') {
-          return Promise.resolve({ Data: [{ _id: 'p1', tipo_evaluacion_id: 7, dependencia_id: 42, titulo: 'Padre' }] });
+        if (resource === 'auditoria/auditor') {
+          return Promise.resolve({ Data: [{ _id: 'h1', auditoria_padre_id: 'p1', }], });
         }
         // para enriquecerAuditorias -> auditoria-estado
         if (resource === 'auditoria-estado') {
@@ -86,23 +87,27 @@ describe('AuditoriaService', () => {
       expect(res.Data[0].tipo_evaluacion_id).toBe(7);
       expect(res.Data[0].dependencia_id).toBe(42);
       expect(res.MetaData.Count).toBe(1);
-      // verificar que se consultaron las auditorías del auditor con el query correcto (incluye tipo_evaluacion)
+      // verificar que la consulta a las auditorías del auditor incluyó filtros de hija
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria/auditor',
+        expect.any(String),
+        expect.objectContaining({ query: expect.stringContaining('activo:true') }),
+      );
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria/auditor',
+        expect.any(String),
+        expect.objectContaining({ query: expect.stringContaining('auditoria_padre_id__in:') }),
+      );
       expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
         'auditoria/auditor',
         'personaX',
-        expect.objectContaining({ query: expect.stringContaining('tipo_evaluacion_id:7') }),
+        expect.any(Object),
       );
       // verificar que se llamó a traerDataCrud para padres con el query correcto (incluye tipo_evaluacion)
       expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
         'auditoria-padre',
         null,
         expect.objectContaining({ query: expect.stringContaining('tipo_evaluacion_id:7') }),
-      );
-      // y que la consulta inicial por auditor se llamó con el personaId
-      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
-        'auditoria/auditor',
-        'personaX',
-        expect.any(Object),
       );
         // verificar que se llamó a traerDataCrud para obtener padres con los fields esperados
         const calls = mockCrudService.traerDataCrud.mock.calls;

--- a/src/application/auditoria/auditoria.service.spec.ts
+++ b/src/application/auditoria/auditoria.service.spec.ts
@@ -51,61 +51,6 @@ describe('AuditoriaService', () => {
     expect(service).toBeDefined();
   });
 
-  // describe('getAuditoriasOrdenadas', () => {
-  //   it('debe lanzar error si no se proporciona plan_auditoria_id', async () => {
-  //     const queryParams = {};
-
-  //     await expect(service.getAuditoriasOrdenadas(queryParams)).rejects.toThrow(
-  //       'El parámetro "plan_auditoria_id" es obligatorio.',
-  //     );
-  //   });
-
-  //   it('debe extraer plan_auditoria_id del parámetro directo', async () => {
-  //     const queryParams = { plan_auditoria_id: '123' };
-  //     const mockAuditorias = {
-  //       Data: [
-  //         { _id: '1', titulo: 'A', activo: true },
-  //         { _id: '2', titulo: 'B', activo: true },
-  //       ],
-  //     };
-  //     const mockPlan = { Data: { auditorias: [] } };
-  //     const mockEstado = { Data: [] };
-
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockAuditorias }));
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockPlan }));
-
-  //     const resultado = await service.getAuditoriasOrdenadas(queryParams);
-
-  //     expect(resultado.Data).toBeDefined();
-  //     expect(resultado.Data.length).toBe(2);
-  //   });
-
-  //   it('debe filtrar solo auditorías activas', async () => {
-  //     const queryParams = { plan_auditoria_id: '123' };
-  //     const mockAuditorias = {
-  //       Data: [
-  //         { _id: '1', titulo: 'A', activo: true },
-  //         { _id: '2', titulo: 'B', activo: false },
-  //         { _id: '3', titulo: 'C', activo: true },
-  //       ],
-  //     };
-  //     const mockPlan = { Data: { auditorias: [] } };
-  //     const mockEstado = { Data: [] };
-
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockAuditorias }));
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockPlan }));
-
-  //     const resultado = await service.getAuditoriasOrdenadas(queryParams);
-
-  //     expect(resultado.Data.length).toBe(2);
-  //     expect(resultado.Data.every((a: any) => a.activo === true)).toBe(true);
-  //   });
-  // });
-
   describe('herencia de campos padre', () => {
     it('getByAuditor debe heredar tipo_evaluacion_id y dependencia_id desde padre', async () => {
       // preparar mocks: traerDataCrud llamado para 'auditoria/auditor', 'auditoria-padre', 'auditoria-estado'

--- a/src/application/auditoria/auditoria.service.spec.ts
+++ b/src/application/auditoria/auditoria.service.spec.ts
@@ -96,7 +96,7 @@ describe('AuditoriaService', () => {
       expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
         'auditoria/auditor',
         expect.any(String),
-        expect.objectContaining({ query: expect.stringContaining('auditoria_padre_id__in:') }),
+        expect.objectContaining({ query: expect.stringContaining('auditoria_padre_id__in:p1') }),
       );
       expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
         'auditoria/auditor',
@@ -184,7 +184,7 @@ describe('AuditoriaService', () => {
         const hijaParams = hijaCall![2];
         expect(hijaParams.query).toContain('activo:true');
         expect(hijaParams.query).toContain('auditoria_padre_id__in:');
-        expect(hijaParams.query).toContain('tipo_evaluacion_id:9');
+        expect(hijaParams.query).not.toContain('tipo_evaluacion_id:9');
     });
   });
 });

--- a/src/application/auditoria/auditoria.service.spec.ts
+++ b/src/application/auditoria/auditoria.service.spec.ts
@@ -3,6 +3,7 @@ import { AuditoriaService } from './auditoria.service';
 import { HttpService } from '@nestjs/axios';
 import { AuditorService } from '../../auditor/auditor.service';
 import { DominiosService } from 'src/shared/utils/dominios/dominios.service';
+import { AuditoriaCrudService } from 'src/shared/services/auditoria-crud/auditoria-crud.service';
 import { of, throwError } from 'rxjs';
 import { HttpException, HttpStatus } from '@nestjs/common';
 
@@ -23,6 +24,10 @@ describe('AuditoriaService', () => {
     getDependencias: jest.fn(),
   };
 
+  const mockCrudService = {
+    traerDataCrud: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -30,6 +35,7 @@ describe('AuditoriaService', () => {
         { provide: HttpService, useValue: mockHttpService },
         { provide: AuditorService, useValue: mockAuditorService },
         { provide: DominiosService, useValue: mockDominiosService },
+        { provide: AuditoriaCrudService, useValue: mockCrudService },
       ],
     }).compile();
 
@@ -45,58 +51,190 @@ describe('AuditoriaService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getAuditoriasOrdenadas', () => {
-    it('debe lanzar error si no se proporciona plan_auditoria_id', async () => {
-      const queryParams = {};
+  // describe('getAuditoriasOrdenadas', () => {
+  //   it('debe lanzar error si no se proporciona plan_auditoria_id', async () => {
+  //     const queryParams = {};
 
-      await expect(service.getAuditoriasOrdenadas(queryParams)).rejects.toThrow(
-        'El parámetro "plan_auditoria_id" es obligatorio.',
+  //     await expect(service.getAuditoriasOrdenadas(queryParams)).rejects.toThrow(
+  //       'El parámetro "plan_auditoria_id" es obligatorio.',
+  //     );
+  //   });
+
+  //   it('debe extraer plan_auditoria_id del parámetro directo', async () => {
+  //     const queryParams = { plan_auditoria_id: '123' };
+  //     const mockAuditorias = {
+  //       Data: [
+  //         { _id: '1', titulo: 'A', activo: true },
+  //         { _id: '2', titulo: 'B', activo: true },
+  //       ],
+  //     };
+  //     const mockPlan = { Data: { auditorias: [] } };
+  //     const mockEstado = { Data: [] };
+
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockAuditorias }));
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockPlan }));
+
+  //     const resultado = await service.getAuditoriasOrdenadas(queryParams);
+
+  //     expect(resultado.Data).toBeDefined();
+  //     expect(resultado.Data.length).toBe(2);
+  //   });
+
+  //   it('debe filtrar solo auditorías activas', async () => {
+  //     const queryParams = { plan_auditoria_id: '123' };
+  //     const mockAuditorias = {
+  //       Data: [
+  //         { _id: '1', titulo: 'A', activo: true },
+  //         { _id: '2', titulo: 'B', activo: false },
+  //         { _id: '3', titulo: 'C', activo: true },
+  //       ],
+  //     };
+  //     const mockPlan = { Data: { auditorias: [] } };
+  //     const mockEstado = { Data: [] };
+
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockAuditorias }));
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
+  //     mockHttpService.get.mockReturnValueOnce(of({ data: mockPlan }));
+
+  //     const resultado = await service.getAuditoriasOrdenadas(queryParams);
+
+  //     expect(resultado.Data.length).toBe(2);
+  //     expect(resultado.Data.every((a: any) => a.activo === true)).toBe(true);
+  //   });
+  // });
+
+  describe('herencia de campos padre', () => {
+    it('getByAuditor debe heredar tipo_evaluacion_id y dependencia_id desde padre', async () => {
+      // preparar mocks: traerDataCrud llamado para 'auditoria/auditor', 'auditoria-padre', 'auditoria-estado'
+      mockCrudService.traerDataCrud.mockImplementation((resource: string, id: any, params: any) => {
+        if (resource === 'auditoria/auditor') {
+          return Promise.resolve({
+            Data: [{
+              _id: 'h1',
+              auditoria_padre_id: 'p1',
+              cronograma_nombre: [],
+              titulo: 'Hija'
+            }],
+            MetaData: { Count: 1 },
+          });
+        }
+        if (resource === 'auditoria-padre') {
+          return Promise.resolve({ Data: [{ _id: 'p1', tipo_evaluacion_id: 7, dependencia_id: 42, titulo: 'Padre' }] });
+        }
+        // para enriquecerAuditorias -> auditoria-estado
+        if (resource === 'auditoria-estado') {
+          return Promise.resolve({ Data: [{ actual: true, estado_id: 1 }] });
+        }
+        return Promise.resolve({ Data: [] });
+      });
+
+      mockAuditorService.getAll.mockResolvedValue({ Data: [] });
+      mockDominiosService.getParametros.mockReturnValue(of({ parametros: [] }));
+      mockDominiosService.getDependencias.mockReturnValue(of({ parametros: [] }));
+
+      const res = await service.getByAuditor('personaX', { query: 'tipo_evaluacion_id:7' });
+      expect(res.Data).toBeDefined();
+      expect(res.Data.length).toBe(1);
+      expect(res.Data[0].tipo_evaluacion_id).toBe(7);
+      expect(res.Data[0].dependencia_id).toBe(42);
+      expect(res.MetaData.Count).toBe(1);
+      // verificar que se consultaron las auditorías del auditor con el query correcto (incluye tipo_evaluacion)
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria/auditor',
+        'personaX',
+        expect.objectContaining({ query: expect.stringContaining('tipo_evaluacion_id:7') }),
       );
+      // verificar que se llamó a traerDataCrud para padres con el query correcto (incluye tipo_evaluacion)
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria-padre',
+        null,
+        expect.objectContaining({ query: expect.stringContaining('tipo_evaluacion_id:7') }),
+      );
+      // y que la consulta inicial por auditor se llamó con el personaId
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria/auditor',
+        'personaX',
+        expect.any(Object),
+      );
+        // verificar que se llamó a traerDataCrud para obtener padres con los fields esperados
+        const calls = mockCrudService.traerDataCrud.mock.calls;
+        const llamóPadre = calls.some(([resource, id, params]) =>
+          resource === 'auditoria-padre' && params && params.fields && params.fields.includes('tipo_evaluacion_id') && params.fields.includes('dependencia_id')
+        );
+        expect(llamóPadre).toBe(true);
     });
 
-    it('debe extraer plan_auditoria_id del parámetro directo', async () => {
-      const queryParams = { plan_auditoria_id: '123' };
-      const mockAuditorias = {
-        Data: [
-          { _id: '1', titulo: 'A', activo: true },
-          { _id: '2', titulo: 'B', activo: true },
-        ],
-      };
-      const mockPlan = { Data: { auditorias: [] } };
-      const mockEstado = { Data: [] };
+    it('getByDependencia debe heredar tipo_evaluacion_id y dependencia_id desde padre', async () => {
+      // mock para getDependenciasByPersona (httpService.get)
+      mockHttpService.get.mockReturnValueOnce(of({ data: [{ DependenciaId: 42 }] }));
 
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockAuditorias }));
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockPlan }));
+      // mock traerDataCrud para 'auditoria-padre', 'auditoria' y 'auditoria-estado'
+      mockCrudService.traerDataCrud.mockImplementation((resource: string, id: any, params: any) => {
+        if (resource === 'auditoria-padre') {
+          return Promise.resolve({
+            Data: [{
+              _id: 'p1',
+              tipo_evaluacion_id: 9,
+              dependencia_id: 42,
+              cronograma_nombre: [],
+              titulo: 'PadreD'
+            }],
+            MetaData: { Count: 1 },
+          });
+        }
+        if (resource === 'auditoria') {
+          return Promise.resolve({ Data: [{ _id: 'h2', auditoria_padre_id: 'p1', titulo: 'HijaD' }] });
+        }
+        if (resource === 'auditoria-estado') {
+          return Promise.resolve({ Data: [{ actual: true, estado_id: 2 }] });
+        }
+        return Promise.resolve({ Data: [] });
+      });
 
-      const resultado = await service.getAuditoriasOrdenadas(queryParams);
+      mockAuditorService.getAll.mockResolvedValue({ Data: [] });
+      mockDominiosService.getParametros.mockReturnValue(of({ parametros: [] }));
+      mockDominiosService.getDependencias.mockReturnValue(of({ parametros: [{ Id: 42, Nombre: 'Dep42' }] }));
 
-      expect(resultado.Data).toBeDefined();
-      expect(resultado.Data.length).toBe(2);
-    });
+      const res = await service.getByDependencia(1, 312, { query: 'tipo_evaluacion_id:9' });
+      expect(res.Data).toBeDefined();
+      expect(res.Data.length).toBe(1);
+      expect(res.Data[0].tipo_evaluacion_id).toBe(9);
+      expect(res.Data[0].dependencia_id).toBe(42);
+      expect(res.MetaData.Count).toBe(1);
+      // verificar que se consultaron las vinculaciones del tercero con los params correctos
+      expect(mockHttpService.get).toHaveBeenCalledWith(
+        expect.stringContaining('vinculacion?query=TerceroPrincipalId:1,Activo:true,CargoId:312&fields=DependenciaId'),
+      );
+      // verificar que se llamó a traerDataCrud para auditoria-padre con filtro por dependencia y tipo_evaluacion
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria-padre',
+        null,
+        expect.objectContaining({ query: expect.stringContaining('dependencia_id__in:42') }),
+      );
+      // y que la consulta de hijas incluyó el filtro activo y auditoria_padre_id__in
+      expect(mockCrudService.traerDataCrud).toHaveBeenCalledWith(
+        'auditoria',
+        null,
+        expect.objectContaining({ query: expect.stringContaining('auditoria_padre_id__in:p1') }),
+      );
+        // verificar query usado para traer padres incluye filtro por dependencia
+        const calls = mockCrudService.traerDataCrud.mock.calls;
+        const padreCall = calls.find(([resource]) => resource === 'auditoria-padre');
+        expect(padreCall).toBeDefined();
+        const padreParams = padreCall![2];
+        expect(padreParams.query).toContain('dependencia_id__in:');
+        expect(padreParams.query).toContain('tipo_evaluacion_id:9');
 
-    it('debe filtrar solo auditorías activas', async () => {
-      const queryParams = { plan_auditoria_id: '123' };
-      const mockAuditorias = {
-        Data: [
-          { _id: '1', titulo: 'A', activo: true },
-          { _id: '2', titulo: 'B', activo: false },
-          { _id: '3', titulo: 'C', activo: true },
-        ],
-      };
-      const mockPlan = { Data: { auditorias: [] } };
-      const mockEstado = { Data: [] };
-
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockAuditorias }));
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockEstado }));
-      mockHttpService.get.mockReturnValueOnce(of({ data: mockPlan }));
-
-      const resultado = await service.getAuditoriasOrdenadas(queryParams);
-
-      expect(resultado.Data.length).toBe(2);
-      expect(resultado.Data.every((a: any) => a.activo === true)).toBe(true);
+        // verificar que las hijas se solicitaron con filtro activo y auditoria_padre_id__in
+        const hijaCall = calls.find(([resource]) => resource === 'auditoria');
+        expect(hijaCall).toBeDefined();
+        const hijaParams = hijaCall![2];
+        expect(hijaParams.query).toContain('activo:true');
+        expect(hijaParams.query).toContain('auditoria_padre_id__in:');
+        expect(hijaParams.query).toContain('tipo_evaluacion_id:9');
     });
   });
 });

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -88,29 +88,33 @@ export class AuditoriaService {
   }
 
   async getByAuditor(personaId: string, queryParams: any) {
-    const { estado_id, ...crudParams } = queryParams;
-
-    if (crudParams.query) {
-      crudParams.query = crudParams.query
+    if (queryParams.query) {
+      queryParams.query = queryParams.query
         .split(',')
         .filter((param: string) => !param.startsWith('estado_id:'))
         .join(',');
     }
 
-    const data = await this.auditoriaCrudService.traerDataCrud('auditoria/auditor', personaId, crudParams);
+    const data = await this.auditoriaCrudService.traerDataCrud('auditoria/auditor', personaId, queryParams);
     const auditorias: any[] = data.Data;
 
     if (auditorias.length > 0) {
-      const padres_ids: string[] = auditorias.map(a => a?.auditoria_padre_id);
-      if (crudParams?.query) {
-        crudParams.query += `,_id__in:${padres_ids.join("|")}`
-      } else {
-        crudParams.query = `_id__in:${padres_ids.join("|")}`
+      const padres_ids: string[] = Array.from(new Set(auditorias.map(a => a?.auditoria_padre_id).filter(Boolean)));
+
+      let padreQueryStr = `_id__in:${padres_ids.join('|')}`;
+      if (queryParams.query) {
+        padreQueryStr = `${queryParams.query},${padreQueryStr}`;
       }
-  
-      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams);
+
+      const queryPadre = {
+        query: padreQueryStr,
+        limit: 0,
+        fields: '_id,titulo,tipo_evaluacion_id,macroproceso_id,proceso_id,dependencia_id',
+      };
+
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryPadre);
       const auditorias_padre: any[] = data2.Data;
-      
+
       const padresMap = Object.fromEntries(auditorias_padre.map(p => [p?._id, p]));
       const auditorias_unidas: any[] = auditorias.map(a => {
         if (a?.auditoria_padre_id in padresMap) {
@@ -119,21 +123,14 @@ export class AuditoriaService {
             ...a,
           };
         }
+        return a;
       });
-  
+
       data.Data = auditorias_unidas;
       data.MetaData.Count = auditorias_unidas.length;
     }
     
     await this.enriquecerAuditorias(data.Data);
-
-    if (estado_id && estado_id !== '') {
-      const estadoId = parseInt(estado_id);
-      data.Data = data.Data.filter(
-        (auditoria: any) => auditoria.estado_id === estadoId,
-      );
-      data.MetaData.Count = data.Data.length;
-    }
 
     if (await this.identificarCampo(data)) {
       this.reemplazarCampos(data);
@@ -158,22 +155,54 @@ export class AuditoriaService {
     }
 
     const dependenciasFilter = dependenciaIds.join('|');
-    const baseQuery = queryParams.query || '';
+
+    const queryEstado = queryParams.query
+      ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id:'))[0]
+      : undefined;
+
+    const queryPadreBase = queryParams.query
+      ? queryParams.query.split(',').filter((param: string) => !param.startsWith('estado_id:')).join(',')
+      : '';
 
     const additionalFilters = `dependencia_id__in:${dependenciasFilter}`;
-    queryParams.query = baseQuery
-      ? `${baseQuery},${additionalFilters}`
-      : additionalFilters;
+    const queryPadreString = queryPadreBase ? `${queryPadreBase},${additionalFilters}` : additionalFilters;
 
-    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryParams);
+    // incluir tipo_evaluacion_id si viene en queryParams.query original
+    const tipoEvalParam = queryParams.query
+      ? queryParams.query.split(',').filter((param: string) => param.startsWith('tipo_evaluacion_id:'))[0]
+      : undefined;
+
+    let queryPadreFinal = queryPadreString;
+    if (tipoEvalParam) {
+      queryPadreFinal = `${tipoEvalParam},${queryPadreFinal}`;
+    }
+
+    const queryPadre = {
+      query: queryPadreFinal,
+      limit: 0,
+      fields: '_id,titulo,tipo_evaluacion_id,macroproceso_id,proceso_id,dependencia_id',
+    };
+
+    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryPadre);
     const auditorias: any[] = data.Data;
 
     if (auditorias.length > 0) {
       const ids: string[] = auditorias.map(a => a?._id);
-      const padresFilter = { query: `auditoria_padre_id__in:${ids.join('|')}`}
-      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, padresFilter);
+
+      // construir query de hijas incluyendo estado (si aplica) y tipo_evaluacion (si aplica)
+      const tipoEvalHija = tipoEvalParam ? tipoEvalParam : undefined;
+      const nuevaQueryParts = [] as string[];
+      if (tipoEvalHija) nuevaQueryParts.push(tipoEvalHija);
+      if (queryEstado) nuevaQueryParts.push(queryEstado);
+      nuevaQueryParts.push('activo:true');
+      nuevaQueryParts.push(`auditoria_padre_id__in:${ids.join('|')}`);
+
+      const nuevaQuery = nuevaQueryParts.join(',');
+
+      const queryHijas = { ...queryParams, query: nuevaQuery };
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria', null, queryHijas);
       const auditorias_hijas: any[] = data2.Data;
-  
+
       const padresMap = Object.fromEntries(auditorias.map(p => [p?._id, p]));
       const auditorias_unidas: any[] = auditorias_hijas.map(a => {
         if (a?.auditoria_padre_id in padresMap) {
@@ -182,8 +211,9 @@ export class AuditoriaService {
             ...a,
           };
         }
+        return a;
       });
-  
+
       data.Data = auditorias_unidas;
       data.MetaData.Count = auditorias_unidas.length;
     }

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -116,15 +116,16 @@ export class AuditoriaService {
       const auditorias_padre: any[] = data2.Data;
 
       const padresMap = Object.fromEntries(auditorias_padre.map(p => [p?._id, p]));
-      const auditorias_unidas: any[] = auditorias.map(a => {
-        if (a?.auditoria_padre_id in padresMap) {
-          return {
-            ...(padresMap[a?.auditoria_padre_id] || {}),
-            ...a,
-          };
-        }
-        return a;
-      });
+      const auditorias_unidas: any[] = auditorias
+          .filter(a =>
+            a?.auditoria_padre_id && a.auditoria_padre_id in padresMap
+          )
+          .map(a => {
+            return {
+              ...(padresMap[a?.auditoria_padre_id] || {}),
+              ...a,
+            }
+          });
 
       data.Data = auditorias_unidas;
       data.MetaData.Count = auditorias_unidas.length;
@@ -204,15 +205,16 @@ export class AuditoriaService {
       const auditorias_hijas: any[] = data2.Data;
 
       const padresMap = Object.fromEntries(auditorias.map(p => [p?._id, p]));
-      const auditorias_unidas: any[] = auditorias_hijas.map(a => {
-        if (a?.auditoria_padre_id in padresMap) {
-          return {
-            ...(padresMap[a?.auditoria_padre_id] || {}),
-            ...a,
-          };
-        }
-        return a;
-      });
+      const auditorias_unidas: any[] = auditorias_hijas
+          .filter( a =>
+            a?.auditoria_padre_id && a.auditoria_padre_id in padresMap
+          )
+          .map(a => {
+            return {
+              ...(padresMap[a?.auditoria_padre_id] || {}),
+              ...a,
+            };
+          });
 
       data.Data = auditorias_unidas;
       data.MetaData.Count = auditorias_unidas.length;

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -90,7 +90,7 @@ export class AuditoriaService {
   async getByAuditor(personaId: string, queryParams: any) {
     const queryEstado = queryParams.query
         ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id:'))[0]
-        : undefined;
+        : '';
 
     if (queryParams.query) {
       queryParams.query = queryParams.query
@@ -114,7 +114,7 @@ export class AuditoriaService {
 
     const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryPadre);
     const auditorias_padre: any[] = data.Data;
-    const padresIds: string[] = Array.from(new Set(auditorias_padre.map(a => a?.auditoria_padre_id).filter(Boolean)));
+    const padresIds: string[] = Array.from(new Set(auditorias_padre.map(a => a?._id).filter(Boolean)));
 
     if (auditorias_padre.length > 0) {
       const nuevaQuery = queryEstado ?
@@ -201,10 +201,8 @@ export class AuditoriaService {
     if (auditorias.length > 0) {
       const ids: string[] = auditorias.map(a => a?._id);
 
-      // construir query de hijas incluyendo estado (si aplica) y tipo_evaluacion (si aplica)
-      const tipoEvalHija = tipoEvalParam ? tipoEvalParam : undefined;
+      // construir query de hijas incluyendo estado (si aplica)
       const nuevaQueryParts = [] as string[];
-      if (tipoEvalHija) nuevaQueryParts.push(tipoEvalHija);
       if (queryEstado) nuevaQueryParts.push(queryEstado);
       nuevaQueryParts.push('activo:true');
       nuevaQueryParts.push(`auditoria_padre_id__in:${ids.join('|')}`);

--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -88,6 +88,10 @@ export class AuditoriaService {
   }
 
   async getByAuditor(personaId: string, queryParams: any) {
+    const queryEstado = queryParams.query
+        ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id:'))[0]
+        : undefined;
+
     if (queryParams.query) {
       queryParams.query = queryParams.query
         .split(',')
@@ -95,25 +99,32 @@ export class AuditoriaService {
         .join(',');
     }
 
-    const data = await this.auditoriaCrudService.traerDataCrud('auditoria/auditor', personaId, queryParams);
-    const auditorias: any[] = data.Data;
-
-    if (auditorias.length > 0) {
-      const padres_ids: string[] = Array.from(new Set(auditorias.map(a => a?.auditoria_padre_id).filter(Boolean)));
-
-      let padreQueryStr = `_id__in:${padres_ids.join('|')}`;
-      if (queryParams.query) {
-        padreQueryStr = `${queryParams.query},${padreQueryStr}`;
+    let padreQueryStr = '';
+    for (const param of queryParams.query.split(',')) {
+      if (param.startsWith('tipo_evaluacion_id:') || param.startsWith('dependencia_id:')) {
+        padreQueryStr += padreQueryStr ? `,${param}` : param;
       }
+    }
 
-      const queryPadre = {
-        query: padreQueryStr,
-        limit: 0,
-        fields: '_id,titulo,tipo_evaluacion_id,macroproceso_id,proceso_id,dependencia_id',
-      };
+    const queryPadre = {
+      query: padreQueryStr,
+      limit: 0,
+      fields: '_id,titulo,tipo_evaluacion_id,macroproceso_id,proceso_id,dependencia_id',
+    };
 
-      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryPadre);
-      const auditorias_padre: any[] = data2.Data;
+    const data = await this.auditoriaCrudService.traerDataCrud('auditoria-padre', null, queryPadre);
+    const auditorias_padre: any[] = data.Data;
+    const padresIds: string[] = Array.from(new Set(auditorias_padre.map(a => a?.auditoria_padre_id).filter(Boolean)));
+
+    if (auditorias_padre.length > 0) {
+      const nuevaQuery = queryEstado ?
+        `${queryEstado},activo:true,auditoria_padre_id__in:${padresIds.join('|')}` :
+        `activo:true,auditoria_padre_id__in:${padresIds.join('|')}`;
+
+      const queryHijas = { ...queryParams, query: nuevaQuery };
+
+      const data2 = await this.auditoriaCrudService.traerDataCrud('auditoria/auditor', personaId, queryHijas);
+      const auditorias: any[] = data2.Data;
 
       const padresMap = Object.fromEntries(auditorias_padre.map(p => [p?._id, p]));
       const auditorias_unidas: any[] = auditorias


### PR DESCRIPTION
This pull request updates the `AuditoriaService` and its test suite to improve the logic for inheriting fields from parent audits and to enhance test coverage for these scenarios. The changes focus on ensuring that child audits correctly inherit `tipo_evaluacion_id` and `dependencia_id` from their parent audits, and on refactoring query construction for better clarity and correctness.

- Based on auditoria udistrital/sisifo_documentacion#595
- Answers to auditoria udistrital/sisifo_documentacion#596

**Key changes include:**

### Test Suite Enhancements

* Added new tests in `auditoria.service.spec.ts` to verify that `getByAuditor` and `getByDependencia` correctly inherit `tipo_evaluacion_id` and `dependencia_id` from parent audits. These tests use detailed mocks to simulate service interactions and validate query construction and data enrichment. [[1]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6R27-R38) [[2]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6L48-R237)

* Commented out the previous `getAuditoriasOrdenadas` tests, focusing the suite on the new inheritance logic.

### Dependency Injection and Mocking

* Injected and mocked the `AuditoriaCrudService` in the test setup to enable more granular and controlled testing of CRUD interactions. [[1]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6R6) [[2]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6R27-R38)

### Service Logic Improvements

* Refactored `getByAuditor` and `getByDependencia` methods to:
  - Properly build queries for parent audits, ensuring that filters such as `tipo_evaluacion_id` and `dependencia_id` are included as needed.
  - Ensure that child audits inherit relevant fields from their parents, using a mapping approach for clarity and correctness. [[1]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L91-R115) [[2]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465R126) [[3]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L130-L137) [[4]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L161-R203) [[5]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465R214)

* Improved query construction by separating filters for state, evaluation type, and dependencies, and by explicitly building query objects for parent and child audit retrieval.

* Removed legacy or redundant filtering logic (such as local filtering by `estado_id` after data retrieval), relying instead on query parameters sent to the CRUD service.

---

**References:**  
- Test enhancements and mocking: [[1]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6R6) [[2]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6R27-R38) [[3]](diffhunk://#diff-018680a6d9e39ab1af03cfd97f9992cab8b508e3a61c974b1ae68d997210b8f6L48-R237)  
- Service logic and query refactoring: [[1]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L91-R115) [[2]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465R126) [[3]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L130-L137) [[4]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L161-R203) [[5]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465R214)