### PR TITLE
fix: Añadir filtro por auditoría padre en getAll aditorías

### DIFF
--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -45,7 +45,7 @@ export class AuditoriaService {
     }
 
     const queryPadre = {
-      query: queryParams.query,
+      query: queryParams.query.replace('auditoria_padre_id', '_id'),
       limit: 0,
       fields: '_id,titulo,tipo_evaluacion_id,macroproceso_id,proceso_id,dependencia_id'
     }


### PR DESCRIPTION
This pull request makes a targeted update to the way parent audit queries are constructed in the `AuditoriaService`. The change ensures that the query uses the correct field name for identifying parent audits.

- Query Construction Update:
  * In `AuditoriaService`, the parent audit query now replaces occurrences of `auditoria_padre_id` with `_id` in the query string to correctly reference the parent audit's identifier.

- related to udistrital/sisifo_documentacion#618