### PR TITLE
feature: 670 concatenacion descargue

### DIFF
--- a/src/application/auditoria-padre/auditoria-padre.service.ts
+++ b/src/application/auditoria-padre/auditoria-padre.service.ts
@@ -238,56 +238,34 @@ export class AuditoriaPadreService {
   }
 
   private reemplazarCampos(data: any) {
-    if (Array.isArray(data.Data)) {
-      data.Data.forEach((element) => {
-        if (element.tipo_evaluacion_id !== undefined) {
-          this.reemplazar(this.tiposEvaluacion, element, 'tipo_evaluacion_id');
-        }
-        if (element.cronograma_id !== undefined) {
-          this.reemplazar(this.cronogramasActividad, element, 'cronograma_id');
-        }
-        if (element.estado_id !== undefined) {
-          this.reemplazar(this.estados, element, 'estado_id');
-        }
-        if (element.macroproceso_id !== undefined) {
-          this.reemplazar(this.macroprocesos, element, 'macroproceso_id');
-        }
-        if (element.vigencia_id !== undefined) {
-          this.reemplazar(this.vigencias, element, 'vigencia_id');
-        }
-        if (element.proceso_id !== undefined) {
-          this.reemplazar(this.procesos, element, 'proceso_id');
-        }
-        if (element.dependencia_id !== undefined) {
-          this.reemplazar(this.dependencias, element, 'dependencia_id');
-        }
+    const procesar = (element: any) => {
+      if (element.tipo_evaluacion_id !== undefined)
+        this.reemplazar(this.tiposEvaluacion, element, 'tipo_evaluacion_id');
+      if (element.cronograma_id !== undefined)
+        this.reemplazar(this.cronogramasActividad, element, 'cronograma_id');
+      if (element.estado_id !== undefined)
+        this.reemplazar(this.estados, element, 'estado_id');
+      if (element.macroproceso_id !== undefined)
+        this.reemplazar(this.macroprocesos, element, 'macroproceso_id');
+      if (element.vigencia_id !== undefined)
+        this.reemplazar(this.vigencias, element, 'vigencia_id');
+      if (element.proceso_id !== undefined)
+        this.reemplazar(this.procesos, element, 'proceso_id');
+      if (element.dependencia_id !== undefined)
+        this.reemplazar(this.dependencias, element, 'dependencia_id');
 
-        element.cronograma = this.unirCronogramaNombres(
-          element.cronograma_nombre,
-        );
-      });
+      const MESES = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+      element.cronograma = this.unirNombres(element.cronograma_nombre, MESES);
+      element.macroproceso = this.unirNombres(element.macroproceso_nombre);
+      element.proceso = this.unirNombres(element.proceso_nombre);
+      element.dependencia = this.unirNombres(element.dependencia_nombre);
+
+    };
+
+    if (Array.isArray(data.Data)) {
+      data.Data.forEach(procesar);
     } else if (typeof data.Data === 'object' && data.Data !== null) {
-      if (data.Data.tipo_evaluacion_id !== undefined) {
-        this.reemplazar(this.tiposEvaluacion, data.Data, 'tipo_evaluacion_id');
-      }
-      if (data.Data.cronograma_id !== undefined) {
-        this.reemplazar(this.cronogramasActividad, data.Data, 'cronograma_id');
-      }
-      if (data.Data.estado_id !== undefined) {
-        this.reemplazar(this.estados, data.Data, 'estado_id');
-      }
-      if (data.Data.macroproceso_id !== undefined) {
-        this.reemplazar(this.macroprocesos, data.Data, 'macroproceso_id');
-      }
-      if (data.Data.vigencia_id !== undefined) {
-        this.reemplazar(this.vigencias, data.Data, 'vigencia_id');
-      }
-      if (data.Data.proceso_id !== undefined) {
-        this.reemplazar(this.procesos, data.Data, 'proceso_id');
-      }
-      if (data.Data.dependencia_id !== undefined) {
-        this.reemplazar(this.dependencias, data.Data, 'dependencia_id');
-      }
+      procesar(data.Data);
     }
     return data;
   }
@@ -311,29 +289,13 @@ export class AuditoriaPadreService {
     return element;
   }
 
-  private unirCronogramaNombres(cronograma_nombre: any[]) {
-    if (Array.isArray(cronograma_nombre) && cronograma_nombre.length === 12) {
-      const mesesCompletos = [
-        'Enero',
-        'Febrero',
-        'Marzo',
-        'Abril',
-        'Mayo',
-        'Junio',
-        'Julio',
-        'Agosto',
-        'Septiembre',
-        'Octubre',
-        'Noviembre',
-        'Diciembre',
-      ];
-      const tieneLosMeses = mesesCompletos.every((mes) =>
-        cronograma_nombre.some((nombre) => nombre === mes),
-      );
-      if (tieneLosMeses) {
-        return 'Todos';
-      }
+  private unirNombres(nombres: any[], todosSiCompletos?: string[]): string {
+    if (!Array.isArray(nombres)) return nombres ?? null;
+    if (todosSiCompletos?.length && nombres.length === todosSiCompletos.length &&
+      todosSiCompletos.every((n) => nombres.includes(n))) {
+      return 'Todos';
     }
-    return unirListaNombresConComas(cronograma_nombre);
+    return unirListaNombresConComas(nombres);
   }
+  
 }

--- a/src/shared/utils/auditoriasExcel.utils.ts
+++ b/src/shared/utils/auditoriasExcel.utils.ts
@@ -31,9 +31,9 @@ const HEADERS = [
 export class AuditoriaExcel {
   titulo: string;
   tipo_evaluacion_nombre: string;
-  macroproceso_nombre?: string;
-  proceso_nombre?: string;
-  dependencia_nombre?: string;
+  macroproceso_nombre?: string[];
+  proceso_nombre?: string[];
+  dependencia_nombre?: string[];
   cronograma_nombre: Array<string>;
   cantidad_auditorias?: string; 
 }
@@ -53,11 +53,11 @@ function dataSourceToExcelData(dataSource: Array<AuditoriaExcel>): Array<object>
     // Tipo de Evaluación
     [HEADERS[2]]: dataSource.map(a => a.tipo_evaluacion_nombre),
     // Macroproceso
-    [HEADERS[3]]: dataSource.map(a => a.macroproceso_nombre || ''),
+    [HEADERS[3]]: dataSource.map(a => a.macroproceso_nombre.join('|') || ''),
     // Proceso
-    [HEADERS[4]]: dataSource.map(a => a.proceso_nombre || ''),
+    [HEADERS[4]]: dataSource.map(a => a.proceso_nombre.join('|') || ''),
     // Dependencia
-    [HEADERS[5]]: dataSource.map(a => a.dependencia_nombre || ''),
+    [HEADERS[5]]: dataSource.map(a => a.dependencia_nombre.join('|') || ''),
     // Cantidad
     [HEADERS[6]]: dataSource.map(a => a.cantidad_auditorias || '')
   };


### PR DESCRIPTION
This pull request updates the Excel utility to accommodate to how field replacement and name joining are handled in the `AuditoriaPadreService`.

Builds on:

- https://github.com/udistrital/plan_anual_auditoria_mid/pull/137

Answers to:

- https://github.com/udistrital/sisifo_documentacion/issues/670

**Excel Export Adjustments:**

* Updated the `AuditoriaExcel` type to define `macroproceso_nombre`, `proceso_nombre`, and `dependencia_nombre` as arrays of strings instead of optional strings, reflecting the new structure used internally.
* Modified the `dataSourceToExcelData` function so that when exporting to Excel, these fields are joined into a single string with a pipe (`|`) separator, ensuring correct formatting in the exported file.