### PR TITLE
feat: 684 multiple macroproceso cargue

### DIFF
--- a/src/application/cargue-masivo/cargue-masivo.service.ts
+++ b/src/application/cargue-masivo/cargue-masivo.service.ts
@@ -145,16 +145,19 @@ export class CargueMasivoService {
         },
         macroproceso_id: {
           file_name_column: 'Macroproceso',
+          separator: '|',
           required: false,
           mapping: await this.getParametrosMapping(TIPO_PARAMETRO.MACROPROCESO),
         },
         proceso_id: {
           file_name_column: 'Proceso',
+          separator: '|',
           required: false,
           mapping: await this.getParametrosMapping(TIPO_PARAMETRO.PROCESO),
         },
         dependencia_id: {
           file_name_column: 'Dependencia',
+          separator: '|',
           required: false,
           mapping: await this.getDependenciasMapping(),
         },

--- a/src/application/cargue-masivo/cargue-masivo.service.ts
+++ b/src/application/cargue-masivo/cargue-masivo.service.ts
@@ -71,7 +71,7 @@ export class CargueMasivoService {
     }
     catch (error) {
       const newError = new Error('Failed to add validations to the template');
-      newError.stack += "\nCaused by: " + error.stack;
+      this.addErrorCause(newError, error);
       throw newError;
     }
   }
@@ -101,7 +101,7 @@ export class CargueMasivoService {
     }
     catch (error) {
       const newError = new Error('Failed to export auditorias to Excel');
-      newError.stack += "\nCaused by: " + error.stack;
+      this.addErrorCause(newError, error);
       throw newError;
     }
   }
@@ -190,7 +190,7 @@ export class CargueMasivoService {
     }
     catch (error) {
       const newError = new Error('Failed to get parametros');
-      newError.stack += "\nCaused by: " + error.stack;
+      this.addErrorCause(newError, error);
       throw newError;
     }
   }
@@ -213,7 +213,7 @@ export class CargueMasivoService {
     }
     catch (error) {
       const newError = new Error('Failed to get dependencias');
-      newError.stack += "\nCaused by: " + error.stack;
+      this.addErrorCause(newError, error);
       throw newError;
     }
   }
@@ -240,6 +240,19 @@ export class CargueMasivoService {
         observacion: { file_name_column: 'Observaciones', required: false },
       },
     };
+  }
+
+  /**
+   * Adds the stack trace of a cause error to a new error's stack trace, ensuring that the original error information is preserved and accessible in the new error.
+   * @param newError The new error to which the cause's stack trace will be added.
+   * @param cause The original error whose stack trace is to be added to the new error.
+   */
+  private addErrorCause(newError: Error, cause: any): void {
+    const causeString = cause instanceof Error
+        ? (cause.stack || cause.message || String(cause))
+        : String(cause);
+    newError.stack = (newError.stack || newError.message || '')
+        + causeString ? ("\nCaused by: " + causeString) : '';
   }
 
 }


### PR DESCRIPTION
This pull request updates the error handling logic in the `CargueMasivoService` to improve how error causes are appended to stack traces, and also adds a configuration change for parameter mappings.

Answers:

- udistrital/sisifo_documentacion#684
- udistrital/sisifo_documentacion#685

**Error Handling Improvements:**

* Introduced a new private method `addErrorCause` to append the stack trace or message of a cause error to a new error's stack trace, replacing the previous direct string concatenation. This ensures more robust and consistent error reporting.
* Updated all relevant `catch` blocks to use the new `addErrorCause` method instead of manually appending error stack traces. This affects error handling in methods related to adding validations, exporting auditorias, and fetching parameters or dependencias. [[1]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L74-R74) [[2]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L104-R104) [[3]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L193-R196) [[4]](diffhunk://#diff-5104676f30d813aff6cdfeae4dd73450ba8de2d5edee0b1a60e98148a5fbeb25L216-R219)

**Parameter Mapping Configuration:**

* Added a `separator: '|'` property to the `macroproceso_id`, `proceso_id`, and `dependencia_id` mappings, which likely controls how multi-value fields are parsed or joined.