### PR TITLE
feat: agregar validacion de observaciones de envio y propiedad tiene_observaciones al plan udistrital/sisifo_documentacion#730

### DIFF
--- a/src/plan-auditoria/plan-auditoria.service.ts
+++ b/src/plan-auditoria/plan-auditoria.service.ts
@@ -92,16 +92,18 @@ export class PlanAuditoriaService {
     if (Array.isArray(Data)) {
       await Promise.all(
         Data.map(async (plan: any) => {
-          const [estado, tieneRechazos, tieneModificaciones, tercero] = await Promise.all([
+          const [estado, tieneRechazos, tieneModificaciones, tieneObservaciones, tercero] = await Promise.all([
             this.traerEstadoPorPlan(plan._id),
             this.traerMotivosRechazo(plan._id, PLAN_ESTADO.RECHAZADO),
             this.tieneModificaciones(plan.auditorias),
+            this.tieneObservacionesEnvio(plan._id),
             plan.creado_por_id ? this.traerTercero(plan.creado_por_id) : null,
           ]);
 
           if (estado?.actual) plan.estado = estado;
           plan.tiene_rechazos = tieneRechazos;
           plan.tiene_modificaciones = tieneModificaciones;
+          plan.tiene_observaciones = tieneObservaciones;
           if (tercero) plan.creado_por_nombre = tercero.NombreCompleto ?? null;
         }),
       );
@@ -121,6 +123,18 @@ export class PlanAuditoriaService {
     }
     const data = await this.auditoriaCrudService.traerDataCrud('estado', null, queryParams);
     return data?.MetaData?.Count > 0;
+  }
+
+  private async tieneObservacionesEnvio(planAuditoriaId: string): Promise<boolean> {
+    const queryParams = {
+      query: `plan_auditoria_id:${planAuditoriaId},estado_id:${PLAN_ESTADO.EN_REVISION_JEFE_ID},activo:true`,
+      limit: 0,
+      fields: '_id,observacion',
+    };
+    const data = await this.auditoriaCrudService.traerDataCrud('estado', null, queryParams);
+    return (data?.Data ?? []).some(
+      (estado: any) => estado.observacion && estado.observacion.trim() !== ''
+    );
   }
 
   private async tieneModificaciones(auditorias: string[]): Promise<boolean> {


### PR DESCRIPTION
### `plan-auditoria.service.ts`
- Nuevo método `tieneObservacionesEnvio()` que consulta estados `EN_REVISION_JEFE_ID` con `observacion != ""`
- Nuevo campo `tiene_observaciones` agregado en `enriquecerPlan()`