### PR TITLE
fix: Se elimina ':' de prefijo de parámetros en servicio de auditoría

### DIFF
--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -34,13 +34,13 @@ export class AuditoriaService {
 
   async getAll(queryParams: any) {
     const queryEstado = queryParams.query
-        ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id:'))[0]
+        ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id'))[0]
         : undefined;
     
     if (queryParams.query) {
       queryParams.query = queryParams.query
         .split(',')
-        .filter((param: string) => !param.startsWith('estado_id:'))
+        .filter((param: string) => !param.startsWith('estado_id'))
         .join(',');
     }
 
@@ -87,22 +87,22 @@ export class AuditoriaService {
 
   async getByAuditor(personaId: string, queryParams: any) {
     const queryEstado = queryParams.query
-        ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id:'))[0]
+        ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id'))[0]
         : '';
 
     if (queryParams.query) {
       queryParams.query = queryParams.query
         .split(',')
-        .filter((param: string) => !param.startsWith('estado_id:'))
+        .filter((param: string) => !param.startsWith('estado_id'))
         .join(',');
     }
 
     let padreQueryStr = '';
     for (const param of queryParams.query.split(',')) {
       if (
-        param.startsWith('tipo_evaluacion_id:') ||
-        param.startsWith('dependencia_id:') ||
-        param.startsWith('vigencia_id:')
+        param.startsWith('tipo_evaluacion_id') ||
+        param.startsWith('dependencia_id') ||
+        param.startsWith('vigencia_id')
       ) {
         padreQueryStr += padreQueryStr ? `,${param}` : param;
       }
@@ -175,11 +175,11 @@ export class AuditoriaService {
     const dependenciasFilter = dependenciaIds.join('|');
 
     const queryEstado = queryParams.query
-      ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id:'))[0]
+      ? queryParams.query.split(',').filter((param: string) => param.startsWith('estado_id'))[0]
       : undefined;
 
     const queryPadreBase = queryParams.query
-      ? queryParams.query.split(',').filter((param: string) => !param.startsWith('estado_id:')).join(',')
+      ? queryParams.query.split(',').filter((param: string) => !param.startsWith('estado_id')).join(',')
       : '';
 
     const additionalFilters = `dependencia_id__in:${dependenciasFilter}`;
@@ -187,7 +187,7 @@ export class AuditoriaService {
 
     // incluir tipo_evaluacion_id si viene en queryParams.query original
     const tipoEvalParam = queryParams.query
-      ? queryParams.query.split(',').filter((param: string) => param.startsWith('tipo_evaluacion_id:'))[0]
+      ? queryParams.query.split(',').filter((param: string) => param.startsWith('tipo_evaluacion_id'))[0]
       : undefined;
 
     let queryPadreFinal = queryPadreString;


### PR DESCRIPTION
This pull request updates the filtering logic in the `AuditoriaService` to make the parameter matching for query strings more flexible. Specifically, it removes the strict requirement for a colon (`:`) after parameter names when filtering, allowing for broader matches. This change affects how query parameters like `estado_id`, `tipo_evaluacion_id`, `dependencia_id`, and `vigencia_id` are identified and processed throughout the service.

- udistrital/sisifo_documentacion#755

**Query parameter filtering improvements:**

* Updated all filtering logic in `getAll`, `getByAuditor`, and related methods to match parameters starting with `estado_id`, `tipo_evaluacion_id`, `dependencia_id`, and `vigencia_id` without requiring a colon, making the service more tolerant of different query formats such as operators. [[1]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L37-R43) [[2]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L90-R105) [[3]](diffhunk://#diff-9caa841b5e018e8e7f37c60b6db73ea68c92ca8e46e5e2a47b76e95a4abce465L178-R190)