### PR TITLE
fix: Filtro incorrecto por auditor tras obtener auditorías por auditor

### DIFF
--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -218,12 +218,6 @@ export class AuditoriaService {
         ...a,
       }));
   
-    auditoriasUnidas = auditoriasUnidas.filter((a: any) =>
-      a.auditores?.some(
-        (auditor: any) => auditor.auditor_id === Number(personaId),
-      ),
-    );
-  
     const result = {
       Data: auditoriasUnidas,
       MetaData: {


### PR DESCRIPTION
This pull request removes a filter from the `AuditoriaService` that previously tried to limit results to only those audits where the given `personaId` was present in the list of auditors in the method `getByAuditor`. This was incorrect because the result came from the `auditoria/auditor` endpoint, so it was already filtered and did not contain the `auditor` field.

- udistrital/sisifo_documentacion#755

Main change:

* Removed the filter in `getByAuditor` that restricted `auditoriasUnidas` to only those audits containing the specified `personaId` in their incorrectly expected auditors list, so all audits are now included in the result.