### PR TITLE
fix: Desplazar momento 5 horas en oficio solicitud de información 

### DIFF
--- a/src/application/plantilla/services/plantilla-solicitud-informacion.service.ts
+++ b/src/application/plantilla/services/plantilla-solicitud-informacion.service.ts
@@ -55,7 +55,7 @@ export class PlantillaSolicitudInformacionService {
       plantilla_id: PLANTILLAS.SOLICITUD_INFORMACION,
       data: {
         logoUDistrital: logoUDistritalOCI,
-        fecha: this.moment().format('D [de] MMMM [de] YYYY'),
+        fecha: this.moment().utcOffset('-05:00').format('D [de] MMMM [de] YYYY'),
         fecha_inicio: this.moment(auditoria.fecha_inicio).format('DD/MM/YYYY'),
         consecutivo_oci: auditoria.consecutivo_OCI,
         dependencias: dependencias,


### PR DESCRIPTION
This pull request introduces a minor update to the way dates are formatted in the `PlantillaSolicitudInformacionService`. The change ensures that the generated date uses the correct UTC offset for the specified timezone.

- udistrital/sisifo_documentacion#780

- Date formatting now explicitly applies a `-05:00` UTC offset when generating the `fecha` field, ensuring consistency with the intended timezone. (`src/application/plantilla/services/plantilla-solicitud-informacion.service.ts`)