### PR TITLE
fix: Devolver conteo correcto en GETs a auditoría

### DIFF
--- a/src/application/auditoria/auditoria.service.ts
+++ b/src/application/auditoria/auditoria.service.ts
@@ -221,7 +221,7 @@ export class AuditoriaService {
     const result = {
       Data: auditoriasUnidas,
       MetaData: {
-        Count: auditoriasUnidas.length,
+        Count: dataHijas?.MetaData?.Count || 0,
       },
     };
   
@@ -346,7 +346,7 @@ export class AuditoriaService {
     const result = {
       Data: auditoriasUnidas,
       MetaData: {
-        Count: auditoriasUnidas.length,
+        Count: dataHijas?.MetaData?.Count || 0,
       },
     };
   


### PR DESCRIPTION
This pull request makes a minor adjustment to how the `Count` property is calculated in the `MetaData` object within the `AuditoriaService`. Instead of using the length of the merged audits array, it now uses the `Count` value from `dataHijas.MetaData` if available, defaulting to 0 otherwise. This ensures consistency with the source metadata instead of counting the returned list's length.

- udistrital/sisifo_documentacion#800