### PR TITLE
feat: creación endpoint plan-mejoramiento con resolución de estados udistrital/sisifo_documentacion#797

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { ConfigModule } from '@nestjs/config';
 import { PlantillaModule } from './application/plantilla/plantilla.module';
 import { CargueMasivoModule } from './application/cargue-masivo/cargue-masivo.module';
 import { PlanMejoramientoAuditorModule } from './application/plan-mejoramiento-auditor/plan-mejoramiento-auditor.module';
+import { PlanMejoramientoModule } from './application/plan-mejoramiento/plan-mejoramiento.module';
 import { ResponsableAccionModule } from './application/responsable-accion/responsable-accion.module';
 import { PlanEstadoModule } from './application/plan-estado/plan-estado.module';
 import { AuditorModule } from './application/auditor/auditor.module';
@@ -51,6 +52,7 @@ import { ServicesModule } from './shared/services/services.module';
     InformeModule,
     AuditadoModule,
     PlanMejoramientoAuditorModule,
+    PlanMejoramientoModule,
     ResponsableAccionModule,
     ServicesModule,
   ],

--- a/src/application/plan-mejoramiento/plan-mejoramiento.controller.ts
+++ b/src/application/plan-mejoramiento/plan-mejoramiento.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, HttpStatus, Res, Query } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { PlanMejoramientoService } from './plan-mejoramiento.service';
+
+@ApiTags('Plan Mejoramiento')
+@Controller('plan-mejoramiento')
+export class PlanMejoramientoController {
+  constructor(private readonly planMejoramientoService: PlanMejoramientoService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Obtiene planes de mejoramiento con estado resuelto.' })
+  @ApiQuery({ name: 'filter', required: false, description: 'Filtro opcional.' })
+  @ApiResponse({ status: 200, description: 'Lista obtenida con éxito.' })
+  @ApiResponse({ status: 404, description: 'No se encontraron registros.' })
+  async getAll(@Res() res: any, @Query() queryParams: any) {
+    try {
+      const data = await this.planMejoramientoService.getAll(queryParams);
+      res.status(HttpStatus.OK).json(data);
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error en servicio GetAll.',
+        Data: error.message,
+      });
+    }
+  }
+}

--- a/src/application/plan-mejoramiento/plan-mejoramiento.module.ts
+++ b/src/application/plan-mejoramiento/plan-mejoramiento.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PlanMejoramientoController } from './plan-mejoramiento.controller';
+import { PlanMejoramientoService } from './plan-mejoramiento.service';
+import { ServicesModule } from 'src/shared/services/services.module';
+import { DominiosModule } from 'src/shared/utils/dominios/dominios.module';
+
+@Module({
+  imports: [ServicesModule, DominiosModule],
+  controllers: [PlanMejoramientoController],
+  providers: [PlanMejoramientoService],
+})
+export class PlanMejoramientoModule {}

--- a/src/application/plan-mejoramiento/plan-mejoramiento.service.ts
+++ b/src/application/plan-mejoramiento/plan-mejoramiento.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+import { AuditoriaCrudService } from 'src/shared/services/auditoria-crud.service';
+import { DominiosService } from 'src/shared/utils/dominios/dominios.service';
+import { environment } from 'src/config/configuration';
+
+const { TIPO_PARAMETRO } = environment;
+
+@Injectable()
+export class PlanMejoramientoService {
+  private estados: { Id: number; Nombre: string }[] = [];
+
+  constructor(
+    private readonly auditoriaCrudService: AuditoriaCrudService,
+    private readonly dominiosService: DominiosService,
+  ) {}
+
+  async getAll(queryParams: any) {
+    await this.cargarEstados();
+    const data = await this.auditoriaCrudService.traerDataCrud('plan-mejoramiento', null, queryParams);
+    this.reemplazarCampos(data);
+    return data;
+  }
+
+  private async cargarEstados(): Promise<void> {
+    if (this.estados.length) return;
+    const dominio = await firstValueFrom(
+      this.dominiosService.getParametros(TIPO_PARAMETRO.AUDITORIA_ESTADO),
+    );
+    this.estados = dominio.parametros as { Id: number; Nombre: string }[];
+  }
+
+  private reemplazarCampos(data: any): void {
+    const procesar = (elemento: any) => {
+      if (elemento?.estado_id !== undefined) {
+        this.reemplazar(this.estados, elemento, 'estado_id');
+      }
+    };
+    if (Array.isArray(data?.Data)) {
+      data.Data.forEach(procesar);
+    } else if (typeof data?.Data === 'object' && data.Data !== null) {
+      procesar(data.Data);
+    }
+  }
+
+  private reemplazar(array: { Id: number; Nombre: string }[], elemento: any, campo: string): void {
+    const value = elemento[campo];
+    const nuevoCampo = campo.replace('_id', '_nombre');
+    const encontrado = array.find((p) => p.Id === value);
+    elemento[nuevoCampo] = encontrado ? encontrado.Nombre : null;
+  }
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1117,6 +1117,32 @@
         ]
       }
     },
+    "/plan-mejoramiento": {
+      "get": {
+        "operationId": "PlanMejoramientoController_getAll",
+        "parameters": [
+          {
+            "name": "filter",
+            "required": false,
+            "in": "query",
+            "description": "Filtro opcional.",
+            "schema": {}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista obtenida con éxito."
+          },
+          "404": {
+            "description": "No se encontraron registros."
+          }
+        },
+        "summary": "Obtiene planes de mejoramiento con estado resuelto.",
+        "tags": [
+          "Plan Mejoramiento"
+        ]
+      }
+    },
     "/responsable-accion": {
       "get": {
         "operationId": "ResponsableAccionController_getAll",

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -716,6 +716,23 @@ paths:
         resueltos.
       tags:
         - Plan Mejoramiento Auditor
+  /plan-mejoramiento:
+    get:
+      operationId: PlanMejoramientoController_getAll
+      parameters:
+        - name: filter
+          required: false
+          in: query
+          description: Filtro opcional.
+          schema: {}
+      responses:
+        '200':
+          description: Lista obtenida con éxito.
+        '404':
+          description: No se encontraron registros.
+      summary: Obtiene planes de mejoramiento con estado resuelto.
+      tags:
+        - Plan Mejoramiento
   /responsable-accion:
     get:
       operationId: ResponsableAccionController_getAll


### PR DESCRIPTION
# Implementación endpoint plan-mejoramiento MID

## Descripción
Se crea el endpoint `GET /plan-mejoramiento` en el MID para centralizar la consulta de planes de mejoramiento y resolver información de estados para consumo frontend.

## Cambios realizados

- Creación módulo `plan-mejoramiento`.
- Integración con CRUD de plan de mejoramiento.
- Resolución de `estado_id` → `estado_nombre` mediante `DominiosService`.
- Registro del módulo en `app.module.ts`.
- Ajuste de respuesta para consumo directo desde frontend.

## Pruebas realizadas

- Validación de consulta al CRUD.
- Validación de resolución de estados.
- Validación de respuesta consumida desde MF.

## Issue relacionada

- udistrital/sisifo_documentacion#797