### PR TITLE
feat: Encabezado y logos de informes de auditoria y seguimiento

### DIFF
--- a/src/application/plantilla/services/plantilla-informe-auditoria.service.ts
+++ b/src/application/plantilla/services/plantilla-informe-auditoria.service.ts
@@ -11,6 +11,8 @@ const {
   TIPO_EVALUACION,
   ESTADOS_INFORME_AUDITORIA_PRELIMINAR,
   CARGO,
+  logoUDistrital,
+  logoSIGUD
 } = environment;
 
 @Injectable()
@@ -70,6 +72,8 @@ export class PlantillaInformeAuditoriaService {
       const infoParaPlantilla = {
         plantilla_id: PLANTILLAS.INFORME_AUDITORIA_INTERNA,
         data: {
+          logoUDistrital: logoUDistrital,
+          logoSIGUD: logoSIGUD,
           consecutivo: auditoria.consecutivo_no_auditoria,
           fecha_emision: {
             dia: dia,

--- a/src/application/plantilla/services/plantilla-informe-seguimiento.service.ts
+++ b/src/application/plantilla/services/plantilla-informe-seguimiento.service.ts
@@ -11,6 +11,8 @@ const {
   TIPO_EVALUACION,
   ESTADOS_INFORME_AUDITORIA_PRELIMINAR,
   CARGO,
+  logoUDistrital,
+  logoSIGUD
 } = environment;
 
 @Injectable()
@@ -100,6 +102,8 @@ export class PlantillaInformeSeguimientoService {
       const infoParaPlantilla = {
         plantilla_id: PLANTILLAS.INFORME_SEGUIMIENTO,
         data: {
+          logoUDistrital: logoUDistrital,
+          logoSIGUD: logoSIGUD,
           consecutivo: auditoria.no_auditoria,
           fecha_emision: {
             dia: dia,


### PR DESCRIPTION
- Se agregan las imagenes para los logos del encabezado del SIGUD en los informes de auditoria y seguimiento.