### PR TITLE
fix: Auditado/{id}/documento ahora devuelve documentos con metadatos vacíos

### DIFF
--- a/src/application/auditado/auditado.service.ts
+++ b/src/application/auditado/auditado.service.ts
@@ -73,6 +73,7 @@ export class AuditadoService {
 
       const dependenciaOk =
         !documento.metadatos ||
+        Object.keys(documento.metadatos).length === 0 ||
         dependenciasAuditado.includes(
           documento.metadatos?.dependencia_id,
         );


### PR DESCRIPTION
This pull request introduces a small but important change to the `AuditadoService` in `auditado.service.ts`. It updates the logic that checks the validity of a document's metadata by also considering the case where the `metadatos` object is empty. This ensures that documents with empty metadata are handled consistently.

- udistrital/sisifo_documentacion#826

* Updated the `dependenciaOk` check to treat documents with empty `metadatos` objects as valid, improving the robustness of metadata validation logic.