### PR TITLE
feat: trasladar sellado de numeracion de hallazgos al MID (PUT numeracion-hallazgo) udistrital/sisifo_documentacion#846

### DIFF
--- a/src/application/informe/informe.controller.ts
+++ b/src/application/informe/informe.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, HttpStatus, Query } from '@nestjs/common';
+import { Controller, Get, Put, Param, HttpStatus, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { InformeService } from './informe.service';
 
@@ -56,5 +56,25 @@ export class InformeController {
     @Param('auditoriaId') auditoriaId: string,
   ) {
     return await this.informeService.getByAuditoria(auditoriaId);
+  }
+
+  @Put('auditoria/:auditoriaId/numeracion-hallazgo')
+  @ApiOperation({
+    summary: 'Asignar/recalcular la numeración de hallazgos del informe',
+    description:
+      'Calcula y persiste el número jerárquico {tema}.{subtema}.{hallazgo} (no_hallazgo) en los hallazgos activos del informe de la auditoría. Idempotente.',
+  })
+  @ApiParam({
+    name: 'auditoriaId',
+    type: 'string',
+    description: 'ID de la auditoría',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Resumen: { total, sellados, fallidos }',
+  })
+  @ApiResponse({ status: 404, description: 'Informe no encontrado' })
+  async actualizarNumeracionHallazgo(@Param('auditoriaId') auditoriaId: string) {
+    return await this.informeService.sellarHallazgos(auditoriaId);
   }
 }

--- a/src/application/informe/informe.service.ts
+++ b/src/application/informe/informe.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, BadRequestException } from '@nestjs/comm
 import { lastValueFrom, forkJoin, of, catchError, from } from 'rxjs';
 import { AuditoriaCrudService } from 'src/shared/services/auditoria-crud.service';
 import { AuditoriaService } from 'src/application/auditoria/auditoria.service';
+import { numerarHallazgos } from 'src/shared/utils/numeracion-hallazgos.util';
 
 @Injectable()
 export class InformeService {
@@ -115,5 +116,90 @@ export class InformeService {
     };
 
     return await this.getAll(queryParams);
+  }
+
+  /**
+   * Sella la numeración jerárquica (`no_hallazgo`) de todos los hallazgos
+   * activos del informe de una auditoría. Se invoca al aprobar el informe
+   * final. Idempotente: recalcula y sobreescribe en cada ejecución.
+   */
+  async sellarHallazgos(auditoriaId: string) {
+    if (!auditoriaId) {
+      throw new BadRequestException('El auditoriaId es requerido');
+    }
+
+    // 1. Informe activo de la auditoría
+    const informeRes = await this.auditoriaCrudService.traerDataCrud(
+      'informe',
+      null,
+      { query: `auditoria_id:${auditoriaId},activo:true`, limit: '1' },
+    );
+    const informeId = informeRes?.Data?.[0]?._id;
+    if (!informeId) {
+      throw new NotFoundException(
+        `No se encontró informe activo para la auditoría ${auditoriaId}`,
+      );
+    }
+
+    // 2. Temas (con subtemas embebidos) + hallazgos activos, en paralelo
+    const [temasRes, hallazgosRes] = await Promise.all([
+      this.auditoriaCrudService.traerDataCrud('tema', null, {
+        query: `informe_id:${informeId},activo:true`,
+        limit: '0',
+      }),
+      this.auditoriaCrudService.traerDataCrud('hallazgo', null, {
+        query: `informe_id:${informeId},activo:true`,
+        limit: '0',
+      }),
+    ]);
+
+    // 3. Calcular numeración jerárquica
+    const numerados = numerarHallazgos(
+      temasRes?.Data ?? [],
+      hallazgosRes?.Data ?? [],
+    );
+    if (numerados.length === 0) {
+      return {
+        Success: true,
+        Status: 200,
+        Message: 'No hay hallazgos activos para sellar.',
+        Data: { informe_id: informeId, total: 0, sellados: 0, fallidos: [] },
+      };
+    }
+
+    // 4. Persistir en lotes (limita la concurrencia contra el CRUD)
+    const TAMANO_LOTE = 25;
+    const fallidos: string[] = [];
+    let sellados = 0;
+
+    for (let i = 0; i < numerados.length; i += TAMANO_LOTE) {
+      const tanda = numerados.slice(i, i + TAMANO_LOTE);
+      const resultados = await Promise.all(
+        tanda.map(async (n) => {
+          try {
+            await this.auditoriaCrudService.put('hallazgo', n.hallazgoId, {
+              no_hallazgo: n.numero,
+            });
+            return true;
+          } catch {
+            fallidos.push(n.hallazgoId);
+            return false;
+          }
+        }),
+      );
+      sellados += resultados.filter(Boolean).length;
+    }
+
+    return {
+      Success: fallidos.length === 0,
+      Status: 200,
+      Message: 'Sellado de hallazgos completado.',
+      Data: {
+        informe_id: informeId,
+        total: numerados.length,
+        sellados,
+        fallidos,
+      },
+    };
   }
 }

--- a/src/shared/utils/numeracion-hallazgos.util.ts
+++ b/src/shared/utils/numeracion-hallazgos.util.ts
@@ -1,0 +1,49 @@
+/**
+ * Numeración jerárquica de hallazgos: {tema}.{subtema}.{hallazgo}.
+ *
+ * Recorre temas activos → subtemas activos → hallazgos activos por
+ * subtema, contando solo activos. El contador de tema arranca en 2
+ * (`temaCount + 1`) — convención del front (la sección "1" del informe
+ * queda reservada). Debe mantenerse en sync con el util homónimo del
+ * frontend (`plan_anual_auditoria_mf`), que se usa solo para display.
+ *
+ * Esta copia es la FUENTE DE VERDAD del número que se persiste al sellar.
+ */
+export interface HallazgoNumerado {
+  hallazgoId: string;
+  numero: string;
+}
+
+export function numerarHallazgos(
+  temas: any[],
+  hallazgos: any[],
+): HallazgoNumerado[] {
+  const resultado: HallazgoNumerado[] = [];
+  let temaCount = 0;
+
+  for (const tema of temas ?? []) {
+    if (!tema.activo) continue;
+    temaCount++;
+    let subtemaCount = 0;
+
+    for (const subtema of tema.subtema ?? []) {
+      if (!subtema.activo) continue;
+      subtemaCount++;
+      let hallazgoCount = 0;
+
+      const subtemaIdStr = subtema._id?.toString();
+      for (const h of (hallazgos ?? []).filter(
+        (h) =>
+          h.subtema_id?.toString() === subtemaIdStr && h.activo !== false,
+      )) {
+        hallazgoCount++;
+        resultado.push({
+          hallazgoId: h._id?.toString(),
+          numero: `${temaCount + 1}.${subtemaCount}.${hallazgoCount}`,
+        });
+      }
+    }
+  }
+
+  return resultado;
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1036,6 +1036,35 @@
         ]
       }
     },
+    "/informe/auditoria/{auditoriaId}/numeracion-hallazgo": {
+      "put": {
+        "description": "Calcula y persiste el número jerárquico {tema}.{subtema}.{hallazgo} (no_hallazgo) en los hallazgos activos del informe de la auditoría. Idempotente.",
+        "operationId": "InformeController_actualizarNumeracionHallazgo",
+        "parameters": [
+          {
+            "name": "auditoriaId",
+            "required": true,
+            "in": "path",
+            "description": "ID de la auditoría",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resumen: { total, sellados, fallidos }"
+          },
+          "404": {
+            "description": "Informe no encontrado"
+          }
+        },
+        "summary": "Asignar/recalcular la numeración de hallazgos del informe",
+        "tags": [
+          "Informe"
+        ]
+      }
+    },
     "/auditado/{personaId}/documento": {
       "get": {
         "operationId": "AuditadoController_filtrarDocumentosPorDependencia",
@@ -1166,6 +1195,94 @@
         "summary": "Obtiene los responsables de acción con nombre de dependencia resuelto.",
         "tags": [
           "Responsable Acción"
+        ]
+      }
+    },
+    "/gestion-accion": {
+      "get": {
+        "operationId": "GestionAccionesController_getAll",
+        "parameters": [
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "hasta",
+            "required": false,
+            "in": "query",
+            "description": "Fecha inicio máxima (ISO).",
+            "schema": {}
+          },
+          {
+            "name": "desde",
+            "required": false,
+            "in": "query",
+            "description": "Fecha inicio mínima (ISO).",
+            "schema": {}
+          },
+          {
+            "name": "dependencia",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "auditor",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "no_accion",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "no_hallazgo",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "nombre_auditoria",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "no_auditoria",
+            "required": false,
+            "in": "query",
+            "schema": {}
+          },
+          {
+            "name": "vigencia_id",
+            "required": true,
+            "in": "query",
+            "description": "Vigencia a consultar.",
+            "schema": {}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista obtenida con éxito."
+          },
+          "404": {
+            "description": "Error en la consulta."
+          }
+        },
+        "summary": "Lista las acciones de mejora de una vigencia con auditoría, hallazgo, auditores y dependencias resueltos.",
+        "tags": [
+          "Gestión de Acciones"
         ]
       }
     }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -661,6 +661,27 @@ paths:
           description: Informes de la auditoría obtenidos
       summary: Obtener informes por auditoría
       tags: *ref_9
+  /informe/auditoria/{auditoriaId}/numeracion-hallazgo:
+    put:
+      description: >-
+        Calcula y persiste el número jerárquico {tema}.{subtema}.{hallazgo}
+        (no_hallazgo) en los hallazgos activos del informe de la auditoría.
+        Idempotente.
+      operationId: InformeController_actualizarNumeracionHallazgo
+      parameters:
+        - name: auditoriaId
+          required: true
+          in: path
+          description: ID de la auditoría
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Resumen: { total, sellados, fallidos }'
+        '404':
+          description: Informe no encontrado
+      summary: Asignar/recalcular la numeración de hallazgos del informe
+      tags: *ref_9
   /auditado/{personaId}/documento:
     get:
       operationId: AuditadoController_filtrarDocumentosPorDependencia
@@ -750,6 +771,67 @@ paths:
       summary: Obtiene los responsables de acción con nombre de dependencia resuelto.
       tags:
         - Responsable Acción
+  /gestion-accion:
+    get:
+      operationId: GestionAccionesController_getAll
+      parameters:
+        - name: offset
+          required: false
+          in: query
+          schema: {}
+        - name: limit
+          required: false
+          in: query
+          schema: {}
+        - name: hasta
+          required: false
+          in: query
+          description: Fecha inicio máxima (ISO).
+          schema: {}
+        - name: desde
+          required: false
+          in: query
+          description: Fecha inicio mínima (ISO).
+          schema: {}
+        - name: dependencia
+          required: false
+          in: query
+          schema: {}
+        - name: auditor
+          required: false
+          in: query
+          schema: {}
+        - name: no_accion
+          required: false
+          in: query
+          schema: {}
+        - name: no_hallazgo
+          required: false
+          in: query
+          schema: {}
+        - name: nombre_auditoria
+          required: false
+          in: query
+          schema: {}
+        - name: no_auditoria
+          required: false
+          in: query
+          schema: {}
+        - name: vigencia_id
+          required: true
+          in: query
+          description: Vigencia a consultar.
+          schema: {}
+      responses:
+        '200':
+          description: Lista obtenida con éxito.
+        '404':
+          description: Error en la consulta.
+      summary: >-
+        Lista las acciones de mejora de una vigencia con auditoría, hallazgo,
+        auditores y dependencias resueltos.
+      tags:
+        - Gestión de Acciones
 info:
   title: Plan Anual Auditoria MID
   description: API MID para la gestion de planes de auditorias, auditorias y actividades


### PR DESCRIPTION
## Descripción

Se traslada al MID el proceso de sellado de numeración de hallazgos, que anteriormente era ejecutado desde el frontend mediante un PUT por cada hallazgo.

La decisión se tomó para centralizar la lógica de negocio y mejorar la robustez del proceso, evitando depender de múltiples peticiones desde el navegador, de la conexión del usuario o de que la sesión permanezca abierta durante toda la ejecución.

Ahora el frontend realiza una única llamada al MID y este se encarga de procesar la numeración y persistencia de todos los hallazgos asociados al informe.

## Cambios realizados

- Se implementó el endpoint:

  ```http
  PUT /informe/auditoria/:auditoriaId/numeracion-hallazgo
  ```

- Se creó el util `numeracion-hallazgos.util.ts`, encargado de centralizar el cálculo de la numeración jerárquica de hallazgos bajo la estructura:

  ```text
  {tema}.{subtema}.{hallazgo}
  ```

- Se implementó el método `sellarHallazgos(auditoriaId)` en `informe.service.ts`, responsable de:

  - Resolver el informe asociado a la auditoría.
  - Obtener los temas y hallazgos activos.
  - Calcular la numeración correspondiente para cada hallazgo.
  - Persistir el campo `no_hallazgo` en el CRUD.
  - Procesar las actualizaciones por lotes para optimizar la ejecución.

- El endpoint retorna un resumen de la ejecución con la cantidad de registros procesados:

  ```json
  {
    "total": 0,
    "sellados": 0,
    "fallidos": 0
  }
  ```

## Comportamiento

- El proceso es idempotente: ejecutar nuevamente el endpoint recalcula y sobrescribe la numeración existente.
- Permite reintentos ante ejecuciones parciales o fallidas.
- No requiere transacciones ni mecanismos adicionales de recuperación.
- Ante un error durante el sellado, la aprobación del informe no se bloquea; el frontend informa la situación y el proceso puede ejecutarse nuevamente posteriormente.