### PR TITLE
feat: 854 exportar excel

### DIFF
--- a/src/application/cargue-masivo/cargue-masivo.controller.ts
+++ b/src/application/cargue-masivo/cargue-masivo.controller.ts
@@ -19,6 +19,7 @@ import { environment } from 'src/config/configuration';
 import { NuxeoService } from 'src/shared/services/nuxeo.service';
 import { AuditoriaPadreService } from '../auditoria-padre/auditoria-padre.service';
 import { firstValueFrom } from 'rxjs';
+import { ConstruirExcelInterface } from 'src/shared/utils/construirExcel';
 
 @ApiTags('Cargue Masivo')
 @Controller('cargue-masivo')
@@ -108,6 +109,100 @@ export class CargueMasivoController {
         plantillaResponse,
       );
     return { base64: tablaExportada };
+  }
+
+  @Post('exportar-excel')
+  @ApiOperation({ summary: 'Exportar libro a un archivo de Excel' })
+  @ApiResponse({ status: HttpStatus.INTERNAL_SERVER_ERROR, description: 'Error interno.' })
+  @ApiBody({
+    description: 'Datos necesarios para generar el plan de mejoramiento.',
+    schema: {
+      type: 'object',
+      properties: {
+        worksheets: {
+          type: 'array',
+          description: 'Lista de hojas de cálculo a generar.',
+          items: {
+            type: 'object',
+            description: 'Datos de una hoja de cálculo, incluyendo su nombre y las filas a incluir.',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'Nombre de la hoja de cálculo.',
+              },
+              rows: {
+                type: 'array',
+                description: 'Filas de la hoja de cálculo',
+                items: {
+                  type: 'array',
+                  description: 'Una fila de la hoja de cálculo',
+                  items: {
+                    type: 'string',
+                    description: 'Valor de la celda en formato string.',
+                  },
+                },
+              },       
+            },
+          }
+        }
+      }
+    },
+    examples: {
+      example1: {
+        summary: 'Ejemplo de datos para generar un libro de Excel con dos hojas de cálculo.',
+        value: {
+          worksheets: [
+            {
+              name: 'Hoja1',
+              rows: [
+                ['Encabezado1', 'Encabezado2', 'Encabezado3'],
+                ['Dato1', 'Dato2', 'Dato3'],
+                ['Dato4', 'Dato5', 'Dato6']
+              ]
+            },
+            {
+              name: 'Hoja2',
+              rows: [
+                ['ColumnaA', 'ColumnaB'],
+                ['ValorA1', 'ValorB1'],
+                ['ValorA2', 'ValorB2']
+              ]
+            }
+          ]
+        }
+      }
+    }
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Archivo de plan de mejoramiento descargado exitosamente.',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            base64: {
+              type: 'string',
+              description: 'Archivo de plan de mejoramiento en formato Base64.',
+            },
+          },
+        },
+      },
+    },
+  })
+  async exportarLibroExcel(
+    @Body() datos: ConstruirExcelInterface,
+  ): Promise<{ base64: string }> {
+    try {
+      const tablaExportada = await this.cargueMasivoService.exportarLibroExcel(datos);
+      return { base64: tablaExportada };
+    } catch (error) {
+      console.error('Error al exportar el libro a Excel:', error);
+      throw new HttpException(
+        'Error al exportar el libro a Excel',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
   }
 
   @Post('auditorias')

--- a/src/application/cargue-masivo/cargue-masivo.service.ts
+++ b/src/application/cargue-masivo/cargue-masivo.service.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/shared/utils/base64.utils';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
+import { ConstruirExcelInterface, construirExcel } from 'src/shared/utils/construirExcel';
 
 const { TIPO_PARAMETRO, MESES } = environment;
 
@@ -292,6 +293,23 @@ export class CargueMasivoService {
   }
 
   /**
+   * Exports the given tabular data to an Excel file and returns it in Base64 format.
+   * @param data An object containing the tabular data to be exported.
+   * @returns A promise that resolves with the exported Excel file in Base64 format.
+   * @throws An error if the export process fails, with a message indicating the failure and the original error stack trace.
+   */
+  async exportarLibroExcel(data: ConstruirExcelInterface): Promise<string> {
+    try {
+      const tablaExportadaBuffer = await construirExcel(data);
+      return arrayBufferToBase64(tablaExportadaBuffer);
+    } catch (error) {
+      const newError = new Error('Failed to export auditorias to Excel');
+      this.addErrorCause(newError, error);
+      throw newError;
+    }
+  }
+
+  /**
    * Adds the stack trace of a cause error to a new error's stack trace, ensuring that the original error information is preserved and accessible in the new error.
    * @param newError The new error to which the cause's stack trace will be added.
    * @param cause The original error whose stack trace is to be added to the new error.
@@ -306,4 +324,5 @@ export class CargueMasivoService {
         ? '\nCaused by: ' + causeString
         : '';
   }
+
 }

--- a/src/shared/utils/construirExcel.ts
+++ b/src/shared/utils/construirExcel.ts
@@ -1,0 +1,109 @@
+import ExcelJS from 'exceljs';
+
+/** Maximum column width in characters */
+const MAX_COLUMN_WIDTH = 40;
+
+/**
+ * Interface representing the structure of the data required to construct an Excel file,
+ * including an array of worksheets, where each worksheet has a name and an array of rows,
+ * and each row is an array of strings representing cell values.
+ */
+export interface ConstruirExcelInterface {
+  worksheets: [{
+    name: string;
+    rows: Array<Array<string>>;
+  }]
+}
+
+/**
+ * Constructs an Excel file from the given tabular data and returns it as an ArrayBuffer.
+ * @param data An object containing the tabular data to be included in the Excel file, structured as an array of worksheets, where each worksheet has a name and an array of rows, and each row is an array of strings representing cell values.
+ * @returns A promise that resolves with the constructed Excel file as an ArrayBuffer.
+ * @throws An error if the construction process fails, with a message indicating the failure and the original error stack trace.
+ */
+export async function construirExcel(data: ConstruirExcelInterface): Promise<ArrayBuffer> {
+  const workbook = new ExcelJS.Workbook();
+
+  // Iterate over each worksheet in the input data and construct it in the workbook
+  for (const worksheet of data.worksheets) {
+    try {
+      await construirHojaExcel(workbook, worksheet.name, worksheet.rows);
+    } catch (error) {
+      console.error(`Error al construir la hoja "${worksheet.name}":`, error);
+      throw new Error(`Error al construir la hoja "${worksheet.name}": ${error}`);
+    }
+  }
+
+  // Clear any default themes to avoid issues with styling in the generated Excel file
+  workbook.clearThemes();
+  return await workbook.xlsx.writeBuffer();
+}
+
+
+
+/**
+ * Constructs an Excel worksheet with the given name and rows of data, and adds it to the provided workbook.
+ * @param workbook The ExcelJS workbook to which the new worksheet will be added.
+ * @param name The name of the worksheet to be created.
+ * @param rows An array of arrays of strings representing the tabular data to be inserted into the worksheet, where each inner array corresponds to a row and each string corresponds to a cell value.
+ * @returns A promise that resolves when the worksheet has been successfully constructed and added to the workbook.
+ * @throws An error if the construction process fails, with a message indicating the failure and the original error stack trace.
+ */
+async function construirHojaExcel(workbook: ExcelJS.Workbook, name: string, rows: Array<Array<string>>): Promise<void> {
+  const worksheet = workbook.addWorksheet(name);
+  const rowCount = rows.length;
+  let columnCount = 0;
+  const columnWidths: { [key: number]: number } = {};
+
+  // Show a preview of the rows in the console for debugging
+  console.debug(
+    `Construyendo hoja "${name}" con filas (primeras tres):`,
+    rows.slice(0, 3),
+  )
+
+  // Insert the data into the worksheet
+  rows.forEach((rowData, rowIndex) => {
+    // Update columnCount if the current row has more columns than the previous maximum
+    if (rowData.length > columnCount)
+      columnCount = rowData.length;
+
+    const sheetRow = worksheet.getRow(rowIndex + 1);
+    rowData.forEach((cellData, columnIndex) => {
+      // Set the cell value in the worksheet
+      sheetRow.getCell(columnIndex + 1).value = cellData;
+
+      // Update the width of the current column based on the length of the cell data, ensuring it does not exceed the maximum column width
+      const cellDataWidth = cellData ? cellData.toString().length : 0;
+      columnWidths[columnIndex] = Math.min(
+        Math.max(columnWidths[columnIndex] || 0, cellDataWidth),
+        MAX_COLUMN_WIDTH
+      );
+    });
+  });
+
+  // Set the column widths based on the calculated maximums
+  for (let i = 0; i < columnCount; i++) {
+    worksheet.getColumn(i + 1).width = columnWidths[i] + 2; // Add some padding to the column width
+  }
+
+  // Apply bold font and center alignment to the header row (first row) of the worksheet
+  const headerRow = worksheet.getRow(1);
+  headerRow.font = { bold: true };
+  headerRow.alignment = { vertical: 'middle', horizontal: 'center', wrapText: true };
+
+  // Create a grid border style using the rowCount and columnCount give the cells top-left alignment with wrapping
+  const borderStyle = {
+    top: { style: 'thin' as const },
+    left: { style: 'thin' as const },
+    bottom: { style: 'thin' as const },
+    right: { style: 'thin' as const },
+  };
+  for (let i = 1; i <= rowCount; i++) {
+    const sheetRow = worksheet.getRow(i);
+    for (let j = 1; j <= columnCount; j++) {
+      const cell = sheetRow.getCell(j);
+      cell.border = { ...cell.border, ...borderStyle };
+      cell.alignment = { vertical: 'top', horizontal: 'left', wrapText: true };
+    }
+  }
+}

--- a/src/shared/utils/construirExcel.ts
+++ b/src/shared/utils/construirExcel.ts
@@ -81,16 +81,6 @@ async function construirHojaExcel(workbook: ExcelJS.Workbook, name: string, rows
     });
   });
 
-  // Set the column widths based on the calculated maximums
-  for (let i = 0; i < columnCount; i++) {
-    worksheet.getColumn(i + 1).width = columnWidths[i] + 2; // Add some padding to the column width
-  }
-
-  // Apply bold font and center alignment to the header row (first row) of the worksheet
-  const headerRow = worksheet.getRow(1);
-  headerRow.font = { bold: true };
-  headerRow.alignment = { vertical: 'middle', horizontal: 'center', wrapText: true };
-
   // Create a grid border style using the rowCount and columnCount give the cells top-left alignment with wrapping
   const borderStyle = {
     top: { style: 'thin' as const },
@@ -106,4 +96,14 @@ async function construirHojaExcel(workbook: ExcelJS.Workbook, name: string, rows
       cell.alignment = { vertical: 'top', horizontal: 'left', wrapText: true };
     }
   }
+  
+  // Set the column widths based on the calculated maximums
+  for (let i = 0; i < columnCount; i++) {
+    worksheet.getColumn(i + 1).width = columnWidths[i] + 2; // Add some padding to the column width
+  }
+
+  // Apply bold font and center alignment to the header row (first row) of the worksheet
+  const headerRow = worksheet.getRow(1);
+  headerRow.font = { bold: true };
+  headerRow.alignment = { vertical: 'middle', horizontal: 'center', wrapText: true };
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -585,6 +585,122 @@
         ]
       }
     },
+    "/cargue-masivo/exportar-excel": {
+      "post": {
+        "operationId": "CargueMasivoController_exportarLibroExcel",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Datos necesarios para generar el plan de mejoramiento.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "worksheets": {
+                    "type": "array",
+                    "description": "Lista de hojas de cálculo a generar.",
+                    "items": {
+                      "type": "object",
+                      "description": "Datos de una hoja de cálculo, incluyendo su nombre y las filas a incluir.",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Nombre de la hoja de cálculo."
+                        },
+                        "rows": {
+                          "type": "array",
+                          "description": "Filas de la hoja de cálculo",
+                          "items": {
+                            "type": "array",
+                            "description": "Una fila de la hoja de cálculo",
+                            "items": {
+                              "type": "string",
+                              "description": "Valor de la celda en formato string."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "example1": {
+                  "summary": "Ejemplo de datos para generar un libro de Excel con dos hojas de cálculo.",
+                  "value": {
+                    "worksheets": [
+                      {
+                        "name": "Hoja1",
+                        "rows": [
+                          [
+                            "Encabezado1",
+                            "Encabezado2",
+                            "Encabezado3"
+                          ],
+                          [
+                            "Dato1",
+                            "Dato2",
+                            "Dato3"
+                          ],
+                          [
+                            "Dato4",
+                            "Dato5",
+                            "Dato6"
+                          ]
+                        ]
+                      },
+                      {
+                        "name": "Hoja2",
+                        "rows": [
+                          [
+                            "ColumnaA",
+                            "ColumnaB"
+                          ],
+                          [
+                            "ValorA1",
+                            "ValorB1"
+                          ],
+                          [
+                            "ValorA2",
+                            "ValorB2"
+                          ]
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Archivo de plan de mejoramiento descargado exitosamente.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "base64": {
+                      "type": "string",
+                      "description": "Archivo de plan de mejoramiento en formato Base64."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error interno."
+          }
+        },
+        "summary": "Exportar libro a un archivo de Excel",
+        "tags": [
+          "Cargue Masivo"
+        ]
+      }
+    },
     "/cargue-masivo/auditorias": {
       "post": {
         "operationId": "CargueMasivoController_cargueMasivo",
@@ -1195,94 +1311,6 @@
         "summary": "Obtiene los responsables de acción con nombre de dependencia resuelto.",
         "tags": [
           "Responsable Acción"
-        ]
-      }
-    },
-    "/gestion-accion": {
-      "get": {
-        "operationId": "GestionAccionesController_getAll",
-        "parameters": [
-          {
-            "name": "offset",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "limit",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "hasta",
-            "required": false,
-            "in": "query",
-            "description": "Fecha inicio máxima (ISO).",
-            "schema": {}
-          },
-          {
-            "name": "desde",
-            "required": false,
-            "in": "query",
-            "description": "Fecha inicio mínima (ISO).",
-            "schema": {}
-          },
-          {
-            "name": "dependencia",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "auditor",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "no_accion",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "no_hallazgo",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "nombre_auditoria",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "no_auditoria",
-            "required": false,
-            "in": "query",
-            "schema": {}
-          },
-          {
-            "name": "vigencia_id",
-            "required": true,
-            "in": "query",
-            "description": "Vigencia a consultar.",
-            "schema": {}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Lista obtenida con éxito."
-          },
-          "404": {
-            "description": "Error en la consulta."
-          }
-        },
-        "summary": "Lista las acciones de mejora de una vigencia con auditoría, hallazgo, auditores y dependencias resueltos.",
-        "tags": [
-          "Gestión de Acciones"
         ]
       }
     }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -366,6 +366,80 @@ paths:
           description: Error interno.
       summary: Descargar auditorías en formato Excel
       tags: *ref_5
+  /cargue-masivo/exportar-excel:
+    post:
+      operationId: CargueMasivoController_exportarLibroExcel
+      parameters: []
+      requestBody:
+        required: true
+        description: Datos necesarios para generar el plan de mejoramiento.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                worksheets:
+                  type: array
+                  description: Lista de hojas de cálculo a generar.
+                  items:
+                    type: object
+                    description: >-
+                      Datos de una hoja de cálculo, incluyendo su nombre y las
+                      filas a incluir.
+                    properties:
+                      name:
+                        type: string
+                        description: Nombre de la hoja de cálculo.
+                      rows:
+                        type: array
+                        description: Filas de la hoja de cálculo
+                        items:
+                          type: array
+                          description: Una fila de la hoja de cálculo
+                          items:
+                            type: string
+                            description: Valor de la celda en formato string.
+            examples:
+              example1:
+                summary: >-
+                  Ejemplo de datos para generar un libro de Excel con dos hojas
+                  de cálculo.
+                value:
+                  worksheets:
+                    - name: Hoja1
+                      rows:
+                        - - Encabezado1
+                          - Encabezado2
+                          - Encabezado3
+                        - - Dato1
+                          - Dato2
+                          - Dato3
+                        - - Dato4
+                          - Dato5
+                          - Dato6
+                    - name: Hoja2
+                      rows:
+                        - - ColumnaA
+                          - ColumnaB
+                        - - ValorA1
+                          - ValorB1
+                        - - ValorA2
+                          - ValorB2
+      responses:
+        '200':
+          description: Archivo de plan de mejoramiento descargado exitosamente.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  base64:
+                    type: string
+                    description: Archivo de plan de mejoramiento en formato Base64.
+        '500':
+          description: Error interno.
+      summary: Exportar libro a un archivo de Excel
+      tags: *ref_5
   /cargue-masivo/auditorias:
     post:
       operationId: CargueMasivoController_cargueMasivo
@@ -771,67 +845,6 @@ paths:
       summary: Obtiene los responsables de acción con nombre de dependencia resuelto.
       tags:
         - Responsable Acción
-  /gestion-accion:
-    get:
-      operationId: GestionAccionesController_getAll
-      parameters:
-        - name: offset
-          required: false
-          in: query
-          schema: {}
-        - name: limit
-          required: false
-          in: query
-          schema: {}
-        - name: hasta
-          required: false
-          in: query
-          description: Fecha inicio máxima (ISO).
-          schema: {}
-        - name: desde
-          required: false
-          in: query
-          description: Fecha inicio mínima (ISO).
-          schema: {}
-        - name: dependencia
-          required: false
-          in: query
-          schema: {}
-        - name: auditor
-          required: false
-          in: query
-          schema: {}
-        - name: no_accion
-          required: false
-          in: query
-          schema: {}
-        - name: no_hallazgo
-          required: false
-          in: query
-          schema: {}
-        - name: nombre_auditoria
-          required: false
-          in: query
-          schema: {}
-        - name: no_auditoria
-          required: false
-          in: query
-          schema: {}
-        - name: vigencia_id
-          required: true
-          in: query
-          description: Vigencia a consultar.
-          schema: {}
-      responses:
-        '200':
-          description: Lista obtenida con éxito.
-        '404':
-          description: Error en la consulta.
-      summary: >-
-        Lista las acciones de mejora de una vigencia con auditoría, hallazgo,
-        auditores y dependencias resueltos.
-      tags:
-        - Gestión de Acciones
 info:
   title: Plan Anual Auditoria MID
   description: API MID para la gestion de planes de auditorias, auditorias y actividades


### PR DESCRIPTION
Esta pull request añade un nuevo endpoint para generar un archivo excel dado un payload con toda la información del libro.

- udistrital/sisifo_documentacion#854

## Cambios realizados

- Se ha creado el archivo `src/shared/utils/construirExcel.ts` que expone una interfaz de libros excel (nombre y filas) y una función utilitaria que, usando esa interfaz, genera un libro excel con esas hojas. Cada hoja se genera con un recuadro y con los encabezados en negrilla y centrados

- Se ha creado un endpoint `POST cargue-masivo/exportar-excel` que recibe payloads con la forma de la nueva interfaz y los pasa, a través del servicio, a la nueva función y devuelve una cadena base64 con el archivo resultante.

- Se ha actualizado la documentación de OpenAPI, lo que incluye el nuevo endpoint y la eliminación de un endpoint que, al momento del desarrollo, ya no existía.